### PR TITLE
Remove unused legacy code dependencies

### DIFF
--- a/aiohomematic/model/device.py
+++ b/aiohomematic/model/device.py
@@ -73,7 +73,7 @@ from aiohomematic.exceptions import AioHomematicException, BaseHomematicExceptio
 from aiohomematic.model import week_profile as wp
 from aiohomematic.model.calculated import CalculatedDataPoint
 from aiohomematic.model.custom import data_point as hmce, definition as hmed
-from aiohomematic.model.data_point import BaseParameterDataPoint, CallbackDataPoint
+from aiohomematic.model.data_point import CallbackDataPoint
 from aiohomematic.model.event import GenericEvent
 from aiohomematic.model.generic import DpBinarySensor, GenericDataPoint, GenericDataPointAny
 from aiohomematic.model.support import (
@@ -1026,8 +1026,6 @@ class Channel(LogContextMixin, PayloadMixin):
 
     def add_data_point(self, *, data_point: CallbackDataPoint) -> None:
         """Add a data_point to a channel."""
-        if isinstance(data_point, BaseParameterDataPoint):
-            self._central.add_event_subscription(data_point=data_point)
         if isinstance(data_point, CalculatedDataPoint):
             self._calculated_data_points[data_point.dpk] = data_point
         if isinstance(data_point, GenericDataPoint):
@@ -1280,8 +1278,6 @@ class Channel(LogContextMixin, PayloadMixin):
 
     def _remove_data_point(self, *, data_point: CallbackDataPoint) -> None:
         """Remove a data_point from a channel."""
-        if isinstance(data_point, BaseParameterDataPoint):
-            self._central.remove_event_subscription(data_point=data_point)
         if isinstance(data_point, CalculatedDataPoint):
             del self._calculated_data_points[data_point.dpk]
         if isinstance(data_point, GenericDataPoint):

--- a/tests/test_central.py
+++ b/tests/test_central.py
@@ -1270,8 +1270,6 @@ class TestCentralEventHandling:
     # Note: Tests for start() and stop() error handling require complex setup
     # and are better suited for integration tests with full central initialization
 
-    # Note: add_event_subscription tests are covered by existing integration tests
-
 
 class TestCentralValidation:
     """Test config validation and system information retrieval."""

--- a/tests/test_error_scenarios.py
+++ b/tests/test_error_scenarios.py
@@ -381,36 +381,6 @@ class TestDeviceUtilities:
                 # May fail with mock client
 
 
-class TestEventSubscriptions:
-    """Test event subscription operations."""
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        (
-            "address_device_translation",
-            "do_mock_client",
-            "ignore_devices_on_create",
-            "un_ignore_list",
-        ),
-        [
-            (TEST_DEVICES, True, None, None),
-        ],
-    )
-    async def test_remove_event_subscription_nonexistent(
-        self,
-        central_client_factory_with_ccu_client,
-    ) -> None:
-        """Test removing event subscription for non-existent data point."""
-        central, mock_client, _ = central_client_factory_with_ccu_client
-
-        device = central.get_device(address="VCU6354483")
-        if device:
-            for channel in list(device.channels.values())[:1]:
-                for dp in list(channel.data_points.values())[:1]:
-                    # Try to remove event subscription
-                    central.remove_event_subscription(data_point=dp)
-
-
 class TestCentralCollections:
     """Test central collection access."""
 


### PR DESCRIPTION
This commit removes the legacy callback system that was kept for backward compatibility alongside the new EventBus. The EventBus is now the sole event handling mechanism.

Changes:
- Removed legacy callback dictionaries:
  - _data_point_key_event_subscriptions
  - _data_point_path_event_subscriptions
  - _sysvar_data_point_event_subscriptions

- Removed legacy callback methods:
  - add_event_subscription()
  - remove_event_subscription()
  - get_data_point_path()
  - get_sysvar_data_point_path()
  - data_point_path_event()

- Simplified event publishing:
  - data_point_event() now only uses EventBus
  - sysvar_data_point_path_event() now only uses EventBus

- Updated device.py:
  - Removed calls to add_event_subscription() in add_data_point()
  - Removed calls to remove_event_subscription() in _remove_data_point()

- Updated tests:
  - Removed obsolete test_remove_event_subscription_nonexistent
  - Removed obsolete TestEventSubscriptions class
  - Removed obsolete comment about add_event_subscription tests

- Cleaned up unused imports:
  - BaseParameterDataPointAny
  - AsyncTaskFactory
  - DataPointEventCallback
  - SysvarEventCallback