### PR TITLE
Remove unimplemented unregister methods

### DIFF
--- a/aiohomematic/model/calculated/data_point.py
+++ b/aiohomematic/model/calculated/data_point.py
@@ -329,5 +329,3 @@ class CalculatedDataPoint[ParameterT: ParamType](BaseDataPoint):
         for unregister in self._unregister_callbacks:
             if unregister is not None:
                 unregister()
-
-        super()._unregister_data_point_updated_callback(cb=cb, custom_id=custom_id)

--- a/aiohomematic/model/custom/data_point.py
+++ b/aiohomematic/model/custom/data_point.py
@@ -365,5 +365,3 @@ class CustomDataPoint(BaseDataPoint):
         for unregister in self._unregister_callbacks:
             if unregister is not None:
                 unregister()
-
-        super()._unregister_data_point_updated_callback(cb=cb, custom_id=custom_id)

--- a/aiohomematic/model/data_point.py
+++ b/aiohomematic/model/data_point.py
@@ -522,12 +522,6 @@ class CallbackDataPoint(ABC, LogContextMixin):
         """Set temporary_refreshed_at to current datetime."""
         self._temporary_refreshed_at = refreshed_at
 
-    def _unregister_data_point_updated_callback(self, *, cb: DataPointUpdatedCallback, custom_id: str) -> None:
-        """Unregister data_point updated callback (placeholder for compatibility)."""
-
-    def _unregister_device_removed_callback(self, *, cb: DeviceRemovedCallback) -> None:
-        """Unregister device removed callback (placeholder for compatibility)."""
-
 
 class BaseDataPoint(CallbackDataPoint, PayloadMixin):
     """Base class for regular data point."""

--- a/aiohomematic/model/device.py
+++ b/aiohomematic/model/device.py
@@ -819,12 +819,6 @@ class Device(LogContextMixin, PayloadMixin):
             for dp in self.generic_data_points:
                 dp.emit_data_point_updated_event()
 
-    def unregister_device_updated_callback(self, *, cb: DeviceUpdatedCallback) -> None:
-        """Unregister update callback (placeholder for compatibility)."""
-
-    def unregister_firmware_update_callback(self, *, cb: FirmwareUpdateCallback) -> None:
-        """Unregister firmware update callback (placeholder for compatibility)."""
-
     @inspector
     async def update_firmware(self, *, refresh_after_update_intervals: tuple[int, ...]) -> bool:
         """Update the firmware of the Homematic device."""
@@ -1187,7 +1181,6 @@ class Channel(LogContextMixin, PayloadMixin):
             self._calculated_data_points[data_point.dpk] = data_point
         if isinstance(data_point, GenericDataPoint):
             self._generic_data_points[data_point.dpk] = data_point
-            self._device.register_device_updated_callback(cb=data_point.emit_data_point_updated_event)
         if isinstance(data_point, hmce.CustomDataPoint):
             self._custom_data_point = data_point
         if isinstance(data_point, GenericEvent):
@@ -1457,7 +1450,6 @@ class Channel(LogContextMixin, PayloadMixin):
             del self._calculated_data_points[data_point.dpk]
         if isinstance(data_point, GenericDataPoint):
             del self._generic_data_points[data_point.dpk]
-            self._device.unregister_device_updated_callback(cb=data_point.emit_data_point_updated_event)
         if isinstance(data_point, hmce.CustomDataPoint):
             self._custom_data_point = None
         if isinstance(data_point, GenericEvent):

--- a/tests/test_model_entity.py
+++ b/tests/test_model_entity.py
@@ -118,8 +118,8 @@ class TestDataPointCallbacks:
         device_updated_mock = MagicMock()
         device_removed_mock = MagicMock()
 
-        switch.register_data_point_updated_callback(cb=device_updated_mock, custom_id="some_id")
-        switch.register_device_removed_callback(cb=device_removed_mock)
+        unregister_updated = switch.register_data_point_updated_callback(cb=device_updated_mock, custom_id="some_id")
+        unregister_removed = switch.register_device_removed_callback(cb=device_removed_mock)
         assert switch.value is None
         assert str(switch) == "path: device/status/VCU2128127/4/STATE, name: HmIP-BSM_VCU2128127 State ch4"
         await central.data_point_event(
@@ -142,8 +142,11 @@ class TestDataPointCallbacks:
         assert event.system_event == "deleteDevices"
         assert event.data.get("interface_id") == "CentralTest-BidCos-RF"
         assert event.data.get("addresses") == ["VCU2128127"]
-        switch._unregister_data_point_updated_callback(cb=device_updated_mock, custom_id="some_id")
-        switch._unregister_device_removed_callback(cb=device_removed_mock)
+        # Call the unregister callbacks to clean up
+        if unregister_updated:
+            unregister_updated()
+        if unregister_removed:
+            unregister_removed()
 
         device_updated_mock.assert_called_with(data_point=switch, custom_id="some_id")
         device_removed_mock.assert_called_with()


### PR DESCRIPTION
…ttern

This commit removes several empty placeholder unregister methods that had no implementation and updates the codebase to properly use the modern event bus pattern for callback management.

Changes:
- Remove empty _unregister_data_point_updated_callback() from CallbackDataPoint
- Remove empty _unregister_device_removed_callback() from CallbackDataPoint
- Remove empty unregister_device_updated_callback() from Device
- Remove empty unregister_firmware_update_callback() from Device
- Update CalculatedDataPoint._unregister_data_point_updated_callback() to not call super()
- Update CustomDataPoint._unregister_data_point_updated_callback() to not call super()
- Refactor FirmwareUpdateDataPoint to properly wrap unsubscribe callbacks
- Remove redundant device callback registration in Channel.add_data_point()
- Remove redundant device callback unregistration in Channel._remove_data_point()
- Update tests to use returned unregister callbacks instead of calling removed methods

The event bus pattern already handles cleanup automatically through the unregister callbacks returned by register_* methods, making the explicit unregister_* methods unnecessary.

Fixes potential memory leak where device callback registrations were not being cleaned up.