### PR TITLE
Fix issue analyzer workflow fail

### DIFF
--- a/.github/scripts/analyze_issue.py
+++ b/.github/scripts/analyze_issue.py
@@ -100,7 +100,7 @@ def get_claude_analysis(title: str, body: str, api_key: str) -> dict[str, Any]:
     prompt = CLAUDE_ANALYSIS_PROMPT.format(title=title, body=body or "(empty)", docs=docs_str)
 
     message = client.messages.create(
-        model="claude-3-5-sonnet-20241022", max_tokens=2000, messages=[{"role": "user", "content": prompt}]
+        model="claude-3-5-sonnet-20240620", max_tokens=2000, messages=[{"role": "user", "content": prompt}]
     )
 
     # Parse the JSON response


### PR DESCRIPTION
Update Claude model ID from 'claude-3-5-sonnet-20241022' to 'claude-3-5-sonnet-20240620' The old model ID was returning 404 errors, causing the issue analyzer workflow to fail.

Fixes the error: 'model: claude-3-5-sonnet-20241022' not found