### PR TITLE
Fix HmIP-RGBW/LSC auto-off bug when using transition times

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ import sys
 from types import MappingProxyType
 from typing import Any, Final, NamedTuple, Required, TypedDict
 
-VERSION: Final = "2025.12.37"
+VERSION: Final = "2025.12.38"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/custom/light.py
+++ b/aiohomematic/model/custom/light.py
@@ -572,8 +572,7 @@ class CustomDpIpRGBWLight(TimerUnitMixin, CustomDpDimmer):
     async def _set_on_time_value(self, *, on_time: float, collector: CallParameterCollector | None = None) -> None:
         """Set the on time value with automatic unit conversion."""
         on_time, on_time_unit = self._recalc_unit_timer(time=on_time)
-        if on_time_unit is not None:
-            await self._dp_on_time_unit.send_value(value=on_time_unit, collector=collector)
+        await self._dp_on_time_unit.send_value(value=on_time_unit, collector=collector)
         await self._dp_on_time_value.send_value(value=float(on_time), collector=collector)
 
     async def _set_ramp_time_off_value(
@@ -581,8 +580,7 @@ class CustomDpIpRGBWLight(TimerUnitMixin, CustomDpDimmer):
     ) -> None:
         """Set the ramp time off value with automatic unit conversion."""
         ramp_time, ramp_time_unit = self._recalc_unit_timer(time=ramp_time)
-        if ramp_time_unit is not None:
-            await self._dp_ramp_time_unit.send_value(value=ramp_time_unit, collector=collector)
+        await self._dp_ramp_time_unit.send_value(value=ramp_time_unit, collector=collector)
         await self._dp_ramp_time_value.send_value(value=float(ramp_time), collector=collector)
 
     async def _set_ramp_time_on_value(
@@ -590,8 +588,7 @@ class CustomDpIpRGBWLight(TimerUnitMixin, CustomDpDimmer):
     ) -> None:
         """Set the ramp time on value with automatic unit conversion."""
         ramp_time, ramp_time_unit = self._recalc_unit_timer(time=ramp_time)
-        if ramp_time_unit is not None:
-            await self._dp_ramp_time_unit.send_value(value=ramp_time_unit, collector=collector)
+        await self._dp_ramp_time_unit.send_value(value=ramp_time_unit, collector=collector)
         await self._dp_ramp_time_value.send_value(value=float(ramp_time), collector=collector)
 
 

--- a/aiohomematic/model/custom/mixins.py
+++ b/aiohomematic/model/custom/mixins.py
@@ -362,9 +362,9 @@ class BrightnessMixin:
 class _TimeUnit:
     """Time unit constants for timer conversion."""
 
-    SECONDS: int = 0
-    MINUTES: int = 1
-    HOURS: int = 2
+    SECONDS: str = "S"
+    MINUTES: str = "M"
+    HOURS: str = "H"
 
 
 # Marker value indicating timer is not used
@@ -397,7 +397,7 @@ class TimerUnitMixin:
     _dp_ramp_time_unit: Any
 
     @staticmethod
-    def _recalc_unit_timer(*, time: float) -> tuple[float, int | None]:
+    def _recalc_unit_timer(*, time: float) -> tuple[float, str]:
         """
         Recalculate unit and value of timer.
 
@@ -405,16 +405,19 @@ class TimerUnitMixin:
         - > 16343 seconds -> minutes
         - > 16343 minutes -> hours
 
+        For the NOT_USED marker (111600), returns HOURS as unit to ensure
+        the device interprets the value correctly (111600 hours ≈ 554 days).
+
         Args:
             time: Time value in seconds.
 
         Returns:
-            Tuple of (converted_time, unit) where unit is None if time equals NOT_USED marker.
+            Tuple of (converted_time, unit) where unit is "S"/"M"/"H".
 
         """
         time_unit = _TimeUnit.SECONDS
         if time == _TIMER_NOT_USED:
-            return time, None
+            return time, _TimeUnit.HOURS
         if time > _TIME_UNIT_THRESHOLD:
             time /= 60
             time_unit = _TimeUnit.MINUTES

--- a/aiohomematic/model/data_point.py
+++ b/aiohomematic/model/data_point.py
@@ -730,6 +730,7 @@ class BaseParameterDataPoint[
         "_cached__enabled_by_channel_operation_mode",
         "_current_value",
         "_default",
+        "_enum_value_is_index",
         "_ignore_on_initial_load",
         "_is_forced_sensor",
         "_is_un_ignored",
@@ -1143,8 +1144,15 @@ class BaseParameterDataPoint[
         """Assign parameter data to instance variables."""
         self._type: ParameterType = ParameterType(parameter_data["TYPE"])
         self._values = tuple(parameter_data["VALUE_LIST"]) if parameter_data.get("VALUE_LIST") else None
+        # Determine if ENUM values should be sent as index (int) or string.
+        # HM devices use integer MIN/MAX/DEFAULT → send as index.
+        # HmIP devices use string MIN/MAX/DEFAULT → send as string.
+        raw_min = parameter_data["MIN"]
+        self._enum_value_is_index: bool = (
+            self._type == ParameterType.ENUM and self._values is not None and isinstance(raw_min, int)
+        )
         self._max: ParameterT = self._convert_value(value=parameter_data["MAX"])
-        self._min: ParameterT = self._convert_value(value=parameter_data["MIN"])
+        self._min: ParameterT = self._convert_value(value=raw_min)
         self._default: ParameterT = self._convert_value(value=parameter_data.get("DEFAULT")) or self._min
         flags: int = parameter_data["FLAGS"]
         self._visible: bool = flags & Flag.VISIBLE == Flag.VISIBLE

--- a/aiohomematic/model/generic/action.py
+++ b/aiohomematic/model/generic/action.py
@@ -31,6 +31,10 @@ class DpAction(GenericDataPoint[None, Any]):
 
     def _prepare_value_for_sending(self, *, value: Any, do_validate: bool = True) -> Any:
         """Prepare value before sending."""
-        if (index := get_index_of_value_from_value_list(value=value, value_list=self._values)) is not None:
-            return index
+        # For string-based ENUMs (HmIP), send the string value directly.
+        # For index-based ENUMs (HM), convert string to index.
+        if self._values is not None and isinstance(value, str) and value in self._values:
+            if self._enum_value_is_index:
+                return get_index_of_value_from_value_list(value=value, value_list=self._values)
+            return value
         return value

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+# Version 2025.12.38 (2025-12-20)
+
+## What's Changed
+
+### Bug Fixes
+
+- **Fix time unit parameters for HmIP-RGBW and HmIP-LSC**: Changed time unit values from integers (0, 1, 2) to strings ("S", "M", "H") to match HomeMatic device requirements
+  - Affects `RAMP_TIME_UNIT`, `DURATION_UNIT`, `ON_TIME_UNIT`, and `RAMP_TIME_TO_OFF_UNIT` parameters
+  - Devices: HmIP-RGBW, HmIP-LSC, HmIP-BSL, HmIP-DRG-DALI, HmIPW-WRC6
+  - Resolves issue where devices expected string values but received integers
+
 # Version 2025.12.37 (2025-12-19)
 
 ## What's Changed

--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,17 @@
 
 ### Bug Fixes
 
-- **Fix time unit parameters for HmIP-RGBW and HmIP-LSC**: Changed time unit values from integers (0, 1, 2) to strings ("S", "M", "H") to match HomeMatic device requirements
-  - Affects `RAMP_TIME_UNIT`, `DURATION_UNIT`, `ON_TIME_UNIT`, and `RAMP_TIME_TO_OFF_UNIT` parameters
-  - Devices: HmIP-RGBW, HmIP-LSC, HmIP-BSL, HmIP-DRG-DALI, HmIPW-WRC6
-  - Resolves issue where devices expected string values but received integers
+- **Fix ENUM parameter handling for HmIP devices**: Properly detect and handle string-based ENUMs vs index-based ENUMs
+  - **Root cause**: HM devices use integer MIN/MAX/DEFAULT for ENUMs (send as index), while HmIP devices use string MIN/MAX/DEFAULT (send as string value)
+  - Added `_enum_value_is_index` detection based on `isinstance(MIN, int)` in `BaseParameterDataPoint`
+  - Updated `DpAction` and `DpSelect` to send string values for HmIP devices
+  - Affects all ENUM parameters on HmIP devices including:
+    - Time units: `RAMP_TIME_UNIT`, `DURATION_UNIT`, `ON_TIME_UNIT` (now "S", "M", "H" instead of 0, 1, 2)
+    - Lock commands: `LOCK_TARGET_LEVEL` (now "LOCKED", "UNLOCKED", "OPEN")
+    - Garage commands: `DOOR_COMMAND` (now "OPEN", "CLOSE", "STOP", "PARTIAL_OPEN")
+    - Siren alarms: `ACOUSTIC_ALARM_SELECTION`, `OPTICAL_ALARM_SELECTION`, `SMOKE_DETECTOR_COMMAND`
+    - Light effects: `COLOR`, `COLOR_BEHAVIOUR`
+  - Resolves issues with HmIP-RGBW, HmIP-LSC, HmIP-BSL, HmIP-DRG-DALI, HmIPW-WRC6, and other HmIP devices
 
 # Version 2025.12.37 (2025-12-19)
 

--- a/tests/test_model_action.py
+++ b/tests/test_model_action.py
@@ -50,7 +50,7 @@ class TestActionDataPoint:
             channel_address="VCU9724704:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="LOCK_TARGET_LEVEL",
-            value=2,
+            value="OPEN",
         )
         await action.send_value(value=1)
         assert mock_client.method_calls[-1] == call.set_value(

--- a/tests/test_model_cover.py
+++ b/tests/test_model_cover.py
@@ -16,6 +16,7 @@ from aiohomematic.model.custom.cover import (
     _OPEN_TILT_LEVEL,
     _WD_CLOSED_LEVEL,
     _GarageDoorActivity,
+    _GarageDoorCommand,
 )
 from aiohomematic_test_support import const
 from aiohomematic_test_support.helper import get_prepared_custom_data_point
@@ -978,7 +979,7 @@ class TestCustomDpGarage:
             channel_address="VCU3574044:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=1,
+            value=_GarageDoorCommand.OPEN,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -990,7 +991,7 @@ class TestCustomDpGarage:
             channel_address="VCU3574044:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=3,
+            value=_GarageDoorCommand.CLOSE,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -1003,7 +1004,7 @@ class TestCustomDpGarage:
             channel_address="VCU3574044:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=4,
+            value=_GarageDoorCommand.PARTIAL_OPEN,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -1016,7 +1017,7 @@ class TestCustomDpGarage:
             channel_address="VCU3574044:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=3,
+            value=_GarageDoorCommand.CLOSE,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -1029,7 +1030,7 @@ class TestCustomDpGarage:
             channel_address="VCU3574044:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=1,
+            value=_GarageDoorCommand.OPEN,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await cover.stop()
@@ -1037,7 +1038,7 @@ class TestCustomDpGarage:
             channel_address="VCU3574044:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=2,
+            value=_GarageDoorCommand.STOP,
         )
 
         await central.event_coordinator.data_point_event(
@@ -1123,7 +1124,7 @@ class TestCustomDpGarage:
             channel_address="VCU6166407:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=1,
+            value=_GarageDoorCommand.OPEN,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -1135,7 +1136,7 @@ class TestCustomDpGarage:
             channel_address="VCU6166407:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=3,
+            value=_GarageDoorCommand.CLOSE,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -1148,7 +1149,7 @@ class TestCustomDpGarage:
             channel_address="VCU6166407:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=4,
+            value=_GarageDoorCommand.PARTIAL_OPEN,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -1161,7 +1162,7 @@ class TestCustomDpGarage:
             channel_address="VCU6166407:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=3,
+            value=_GarageDoorCommand.CLOSE,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -1174,7 +1175,7 @@ class TestCustomDpGarage:
             channel_address="VCU6166407:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=1,
+            value=_GarageDoorCommand.OPEN,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await cover.stop()
@@ -1182,7 +1183,7 @@ class TestCustomDpGarage:
             channel_address="VCU6166407:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="DOOR_COMMAND",
-            value=2,
+            value=_GarageDoorCommand.STOP,
         )
 
         await central.event_coordinator.data_point_event(

--- a/tests/test_model_light.py
+++ b/tests/test_model_light.py
@@ -477,7 +477,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 7, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.WHITE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -485,7 +485,10 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "LEVEL": 0.10980392156862745},
+            values={
+                "COLOR_BEHAVIOUR": _ColorBehaviour.ON,
+                "LEVEL": 0.10980392156862745,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 28
@@ -504,7 +507,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 4, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.RED, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.color_name == _FixedColor.RED
@@ -513,7 +516,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 7, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.WHITE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.color_name == _FixedColor.WHITE
@@ -522,7 +525,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 6, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.YELLOW, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.color_name == _FixedColor.YELLOW
@@ -531,7 +534,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 2, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.GREEN, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.color_name == _FixedColor.GREEN
@@ -540,7 +543,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 3, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.TURQUOISE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.color_name == _FixedColor.TURQUOISE
@@ -549,7 +552,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 1, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.BLUE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.color_name == _FixedColor.BLUE
@@ -558,7 +561,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR": 5, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.PURPLE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.color_name == _FixedColor.PURPLE
@@ -580,7 +583,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"DURATION_VALUE": 18, "COLOR_BEHAVIOUR": 1, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": _ColorBehaviour.ON,
+                "DURATION_UNIT": _TimeUnit.SECONDS,
+                "DURATION_VALUE": 18,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -590,7 +598,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "DURATION_UNIT": 1, "DURATION_VALUE": 283, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": _ColorBehaviour.ON,
+                "DURATION_UNIT": _TimeUnit.MINUTES,
+                "DURATION_VALUE": 283,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -600,14 +613,24 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "DURATION_UNIT": 2, "DURATION_VALUE": 277, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": _ColorBehaviour.ON,
+                "DURATION_UNIT": _TimeUnit.HOURS,
+                "DURATION_VALUE": 277,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await light.turn_on(ramp_time=18)
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "RAMP_TIME_VALUE": 18, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": _ColorBehaviour.ON,
+                "RAMP_TIME_UNIT": _TimeUnit.SECONDS,
+                "RAMP_TIME_VALUE": 18,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -615,7 +638,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "RAMP_TIME_UNIT": 1, "RAMP_TIME_VALUE": 283, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": _ColorBehaviour.ON,
+                "RAMP_TIME_UNIT": _TimeUnit.MINUTES,
+                "RAMP_TIME_VALUE": 283,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -623,7 +651,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU6985973:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "RAMP_TIME_UNIT": 2, "RAMP_TIME_VALUE": 277, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": _ColorBehaviour.ON,
+                "RAMP_TIME_UNIT": _TimeUnit.HOURS,
+                "RAMP_TIME_VALUE": 277,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -687,7 +720,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 7, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.WHITE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -697,7 +730,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "LEVEL": 0.39215686274509803},
+            values={"COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 0.39215686274509803},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 100
@@ -720,7 +753,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 4, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.RED, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -731,7 +764,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 7, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.WHITE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -742,7 +775,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 6, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.YELLOW, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -753,7 +786,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 2, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.GREEN, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -764,7 +797,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 3, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.TURQUOISE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -775,7 +808,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 1, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.BLUE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -786,7 +819,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "COLOR": 5, "LEVEL": 1.0},
+            values={"COLOR": _FixedColor.PURPLE, "COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 255
@@ -802,7 +835,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "LEVEL": 0.39215686274509803},
+            values={"COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 0.39215686274509803},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 100
@@ -813,7 +846,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 1, "LEVEL": 0.12941176470588237},
+            values={"COLOR_BEHAVIOUR": _ColorBehaviour.ON, "LEVEL": 0.12941176470588237},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 33
@@ -824,7 +857,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "LEVEL": 0.12941176470588237},
+            values={"COLOR_BEHAVIOUR": "FLASH_MIDDLE", "LEVEL": 0.12941176470588237},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 33
@@ -835,7 +868,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "LEVEL": 0.25882352941176473},
+            values={"COLOR_BEHAVIOUR": "FLASH_MIDDLE", "LEVEL": 0.25882352941176473},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         assert light.brightness == 66
@@ -849,7 +882,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "DURATION_VALUE": 18, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": "FLASH_MIDDLE",
+                "DURATION_UNIT": _TimeUnit.SECONDS,
+                "DURATION_VALUE": 18,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -859,7 +897,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "DURATION_UNIT": 1, "DURATION_VALUE": 283, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": "FLASH_MIDDLE",
+                "DURATION_UNIT": _TimeUnit.MINUTES,
+                "DURATION_VALUE": 283,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -869,14 +912,24 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "DURATION_UNIT": 2, "DURATION_VALUE": 277, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": "FLASH_MIDDLE",
+                "DURATION_UNIT": _TimeUnit.HOURS,
+                "DURATION_VALUE": 277,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await light.turn_on(ramp_time=18)
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "RAMP_TIME_VALUE": 18, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": "FLASH_MIDDLE",
+                "RAMP_TIME_UNIT": _TimeUnit.SECONDS,
+                "RAMP_TIME_VALUE": 18,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -884,7 +937,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "RAMP_TIME_UNIT": 1, "RAMP_TIME_VALUE": 283, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": "FLASH_MIDDLE",
+                "RAMP_TIME_UNIT": _TimeUnit.MINUTES,
+                "RAMP_TIME_VALUE": 283,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -892,7 +950,12 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "RAMP_TIME_UNIT": 2, "RAMP_TIME_VALUE": 277, "LEVEL": 1.0},
+            values={
+                "COLOR_BEHAVIOUR": "FLASH_MIDDLE",
+                "RAMP_TIME_UNIT": _TimeUnit.HOURS,
+                "RAMP_TIME_VALUE": 277,
+                "LEVEL": 1.0,
+            },
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -911,7 +974,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 2, "LEVEL": 1.0},
+            values={"COLOR_BEHAVIOUR": "BLINKING_SLOW", "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -920,7 +983,7 @@ class TestCustomDpIpFixedColorLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU4704397:8",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"COLOR_BEHAVIOUR": 6, "LEVEL": 0.10980392156862745},
+            values={"COLOR_BEHAVIOUR": "FLASH_MIDDLE", "LEVEL": 0.10980392156862745},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -1054,7 +1117,7 @@ class TestCustomDpIpRGBWLight:
         assert mock_client.method_calls[-1] == call.put_paramset(
             channel_address="VCU5629873:1",
             paramset_key_or_link_address=ParamsetKey.VALUES,
-            values={"EFFECT": 1, "LEVEL": 1.0},
+            values={"EFFECT": "EFFECT_01_END_CURRENT_PROFILE", "LEVEL": 1.0},
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 

--- a/tests/test_model_light.py
+++ b/tests/test_model_light.py
@@ -1065,6 +1065,7 @@ class TestCustomDpIpRGBWLight:
             values={
                 "HUE": 44,
                 "SATURATION": 0.66,
+                "DURATION_UNIT": _TimeUnit.HOURS,
                 "DURATION_VALUE": _NOT_USED,
                 "RAMP_TIME_UNIT": _TimeUnit.SECONDS,
                 "RAMP_TIME_VALUE": 5,
@@ -1078,6 +1079,7 @@ class TestCustomDpIpRGBWLight:
             channel_address="VCU5629873:1",
             paramset_key_or_link_address=ParamsetKey.VALUES,
             values={
+                "DURATION_UNIT": _TimeUnit.HOURS,
                 "DURATION_VALUE": _NOT_USED,
                 "RAMP_TIME_UNIT": _TimeUnit.SECONDS,
                 "RAMP_TIME_VALUE": 5,

--- a/tests/test_model_lock.py
+++ b/tests/test_model_lock.py
@@ -9,6 +9,7 @@ import pytest
 
 from aiohomematic.const import WAIT_FOR_CALLBACK, DataPointUsage, ParamsetKey
 from aiohomematic.model.custom import CustomDpIpLock, CustomDpRfLock
+from aiohomematic.model.custom.lock import _LockTargetLevel
 from aiohomematic_test_support import const
 from aiohomematic_test_support.helper import get_prepared_custom_data_point
 
@@ -141,7 +142,7 @@ class TestIpLock:
             channel_address="VCU9724704:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="LOCK_TARGET_LEVEL",
-            value=0,
+            value=_LockTargetLevel.LOCKED,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -153,7 +154,7 @@ class TestIpLock:
             channel_address="VCU9724704:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="LOCK_TARGET_LEVEL",
-            value=1,
+            value=_LockTargetLevel.UNLOCKED,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
         await central.event_coordinator.data_point_event(
@@ -165,7 +166,7 @@ class TestIpLock:
             channel_address="VCU9724704:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="LOCK_TARGET_LEVEL",
-            value=2,
+            value=_LockTargetLevel.OPEN,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 

--- a/tests/test_model_select.py
+++ b/tests/test_model_select.py
@@ -149,7 +149,7 @@ class TestGenericSelect:
             channel_address="VCU6354483:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="WINDOW_STATE",
-            value=1,
+            value="OPEN",
         )
         assert select.value == "OPEN"
 

--- a/tests/test_model_siren.py
+++ b/tests/test_model_siren.py
@@ -9,6 +9,7 @@ import pytest
 
 from aiohomematic.const import WAIT_FOR_CALLBACK, DataPointUsage, ParamsetKey
 from aiohomematic.model.custom import CustomDpIpSiren, CustomDpIpSirenSmoke
+from aiohomematic.model.custom.siren import _SirenCommand
 from aiohomematic_test_support import const
 from aiohomematic_test_support.helper import get_prepared_custom_data_point
 
@@ -73,9 +74,9 @@ class TestIpSiren:
             channel_address="VCU8249617:3",
             paramset_key_or_link_address=ParamsetKey.VALUES,
             values={
-                "ACOUSTIC_ALARM_SELECTION": 3,
-                "OPTICAL_ALARM_SELECTION": 1,
-                "DURATION_UNIT": 0,
+                "ACOUSTIC_ALARM_SELECTION": "FREQUENCY_RISING_AND_FALLING",
+                "OPTICAL_ALARM_SELECTION": "BLINKING_ALTERNATELY_REPEATING",
+                "DURATION_UNIT": "S",
                 "DURATION_VALUE": 30,
             },
             wait_for_callback=WAIT_FOR_CALLBACK,
@@ -90,9 +91,9 @@ class TestIpSiren:
             channel_address="VCU8249617:3",
             paramset_key_or_link_address=ParamsetKey.VALUES,
             values={
-                "ACOUSTIC_ALARM_SELECTION": 3,
-                "OPTICAL_ALARM_SELECTION": 1,
-                "DURATION_UNIT": 0,
+                "ACOUSTIC_ALARM_SELECTION": "FREQUENCY_RISING_AND_FALLING",
+                "OPTICAL_ALARM_SELECTION": "BLINKING_ALTERNATELY_REPEATING",
+                "DURATION_UNIT": "S",
                 "DURATION_VALUE": 30,
             },
             wait_for_callback=WAIT_FOR_CALLBACK,
@@ -119,9 +120,9 @@ class TestIpSiren:
             channel_address="VCU8249617:3",
             paramset_key_or_link_address=ParamsetKey.VALUES,
             values={
-                "ACOUSTIC_ALARM_SELECTION": 0,
-                "OPTICAL_ALARM_SELECTION": 0,
-                "DURATION_UNIT": 0,
+                "ACOUSTIC_ALARM_SELECTION": "DISABLE_ACOUSTIC_SIGNAL",
+                "OPTICAL_ALARM_SELECTION": "DISABLE_OPTICAL_SIGNAL",
+                "DURATION_UNIT": "S",
                 "DURATION_VALUE": 0,
             },
             wait_for_callback=WAIT_FOR_CALLBACK,
@@ -194,7 +195,7 @@ class TestIpSirenSmoke:
             channel_address="VCU2822385:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="SMOKE_DETECTOR_COMMAND",
-            value=2,
+            value=_SirenCommand.ON,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 
@@ -203,7 +204,7 @@ class TestIpSirenSmoke:
             channel_address="VCU2822385:1",
             paramset_key=ParamsetKey.VALUES,
             parameter="SMOKE_DETECTOR_COMMAND",
-            value=1,
+            value=_SirenCommand.OFF,
             wait_for_callback=WAIT_FOR_CALLBACK,
         )
 


### PR DESCRIPTION
Fix HmIP-RGBW/LSC auto-off bug when using transition times When turning on RGB lighting actuators (HmIP-RGBW and HmIP-LSC) with a ramp_time but no on_time, the NOT_USED marker (111600) was sent without specifying DURATION_UNIT. This caused devices to interpret 111600 as seconds (≈3h 41m), leading to unexpected auto-off.

The fix ensures DURATION_UNIT: HOURS is always sent alongside DURATION_VALUE: 111600, so devices interpret it as 111600 hours (≈554 days), effectively keeping the light on permanently as intended.

Closes #2598