### PR TITLE
Add data point quantity metadata

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -2290,6 +2290,83 @@ ScheduleDict: TypeAlias = dict[str, Any]
 """JSON-serializable schedule dictionary for public API."""
 
 
+@unique
+class Quantity(StrEnum):
+    """
+    Semantic quantity describing what a data point measures.
+
+    This classifies the physical or logical quantity a data point represents,
+    independent of any specific smart home platform. Values are universal terms
+    for measurement types and detection categories.
+    """
+
+    # Sensor quantities
+    CO2 = "carbon_dioxide"
+    CURRENT = "current"
+    ENERGY = "energy"
+    ENUM = "enum"
+    FREQUENCY = "frequency"
+    GAS = "gas"
+    HUMIDITY = "humidity"
+    ILLUMINANCE = "illuminance"
+    PM1 = "pm1"
+    PM10 = "pm10"
+    PM25 = "pm25"
+    POWER = "power"
+    PRESSURE = "pressure"
+    SIGNAL_STRENGTH = "signal_strength"
+    TEMPERATURE = "temperature"
+    VOLTAGE = "voltage"
+    VOLUME_FLOW_RATE = "volume_flow_rate"
+    WIND_SPEED = "wind_speed"
+
+    # Binary sensor quantities
+    BATTERY = "battery"
+    HEAT = "heat"
+    MOISTURE = "moisture"
+    MOTION = "motion"
+    OCCUPANCY = "occupancy"
+    OPENING = "opening"
+    PRESENCE = "presence"
+    PROBLEM = "problem"
+    RUNNING = "running"
+    SAFETY = "safety"
+    SMOKE = "smoke"
+    TAMPER = "tamper"
+    WINDOW = "window"
+
+    # Cover quantities
+    BLIND = "blind"
+    GARAGE = "garage"
+    SHADE = "shade"
+    SHUTTER = "shutter"
+
+    # Switch quantities
+    OUTLET = "outlet"
+    SWITCH = "switch"
+
+    # Button quantities
+    IDENTIFY = "identify"
+    RESTART = "restart"
+    UPDATE = "update"
+
+
+@unique
+class ValueBehavior(StrEnum):
+    """
+    Describes how a numeric value behaves over time.
+
+    This is a platform-independent classification of value semantics:
+    - INSTANTANEOUS: Point-in-time reading (e.g., current temperature, voltage)
+    - CUMULATIVE: Running total that may reset (e.g., energy counter after power cycle)
+    - MONOTONIC: Running total that only increases (e.g., lifetime energy consumption)
+    """
+
+    INSTANTANEOUS = "instantaneous"
+    CUMULATIVE = "cumulative"
+    MONOTONIC = "monotonic"
+
+
 # Define public API for this module
 __all__ = tuple(
     sorted(

--- a/aiohomematic/model/custom/climate.py
+++ b/aiohomematic/model/custom/climate.py
@@ -50,7 +50,7 @@ from aiohomematic.model.generic import (
     DpSensor,
     DpSwitch,
 )
-from aiohomematic.property_decorators import DelegatedProperty, Kind, config_property, state_property
+from aiohomematic.property_decorators import DelegatedProperty, Kind, config_property, info_property, state_property
 from aiohomematic.type_aliases import UnsubscribeCallback
 
 _LOGGER: Final = logging.getLogger(__name__)
@@ -152,7 +152,7 @@ class BaseCustomDpClimate(CustomDataPoint):
     """Base Homematic climate data_point."""
 
     __slots__ = (
-        "_capabilities",
+        "_cached_capabilities",
         "_old_manu_setpoint",
         "_peer_level_dp",
         "_peer_state_dp",
@@ -161,13 +161,10 @@ class BaseCustomDpClimate(CustomDataPoint):
 
     _category = DataPointCategory.CLIMATE
 
-    @property
+    @info_property(cached=True)
     def capabilities(self) -> ClimateCapabilities:
         """Return the climate capabilities."""
-        if (caps := getattr(self, "_capabilities", None)) is None:
-            caps = self._compute_capabilities()
-            object.__setattr__(self, "_capabilities", caps)
-        return caps
+        return self._compute_capabilities()
 
     def _compute_capabilities(self) -> ClimateCapabilities:
         """Compute static capabilities. Base implementation returns no profiles."""
@@ -245,7 +242,7 @@ class BaseCustomDpClimate(CustomDataPoint):
         """Return the current activity."""
         return None
 
-    @state_property
+    @config_property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         if self._dp_temperature_maximum.value is not None:
@@ -259,7 +256,7 @@ class BaseCustomDpClimate(CustomDataPoint):
             return self._dp_min_max_value_not_relevant_for_manu_mode.value
         return False
 
-    @state_property
+    @config_property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         if self._dp_temperature_minimum.value is not None:
@@ -488,7 +485,7 @@ class CustomDpRfThermostat(BaseCustomDpClimate):
 
         return profiles
 
-    @property
+    @config_property
     def schedule_profile_nos(self) -> int:
         """Return the number of supported profiles."""
         return len(self._profiles)
@@ -675,7 +672,7 @@ class CustomDpIpThermostat(BaseCustomDpClimate):
     _dp_state: Final = DataPointField(field=Field.STATE, dpt=DpBinarySensor)
     _dp_temperature_offset: Final = DataPointField(field=Field.TEMPERATURE_OFFSET, dpt=DpFloat)
 
-    optimum_start_stop: Final = DelegatedProperty[bool | None](path="_dp_optimum_start_stop.value")
+    optimum_start_stop: Final = DelegatedProperty[bool | None](path="_dp_optimum_start_stop.value", kind=Kind.STATE)
     temperature_offset: Final = DelegatedProperty[float | None](path="_dp_temperature_offset.value", kind=Kind.STATE)
 
     @property
@@ -707,7 +704,7 @@ class CustomDpIpThermostat(BaseCustomDpClimate):
 
         return profiles
 
-    @property
+    @config_property
     def schedule_profile_nos(self) -> int:
         """Return the number of supported profiles."""
         return len(self._profiles)

--- a/aiohomematic/model/custom/cover.py
+++ b/aiohomematic/model/custom/cover.py
@@ -29,7 +29,7 @@ from aiohomematic.model.custom.mixins import PositionMixin, StateChangeArgs
 from aiohomematic.model.custom.registry import DeviceProfileRegistry, ExtendedDeviceConfig
 from aiohomematic.model.data_point import CallParameterCollector, bind_collector
 from aiohomematic.model.generic import DpAction, DpActionSelect, DpActionString, DpFloat, DpSelect, DpSensor
-from aiohomematic.property_decorators import state_property
+from aiohomematic.property_decorators import info_property, state_property
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ class CustomDpCover(PositionMixin, CustomDataPoint):
     """Class for Homematic cover data point."""
 
     __slots__ = (
-        "_capabilities",
+        "_cached_capabilities",
         "_command_processing_lock",
         "_use_group_channel_for_cover_state",
     )
@@ -137,14 +137,6 @@ class CustomDpCover(PositionMixin, CustomDataPoint):
         ):
             return float(self._dp_group_level.value)
         return self._dp_level.value if self._dp_level.value is not None else self._closed_level
-
-    @property
-    def capabilities(self) -> CoverCapabilities:
-        """Return the cover capabilities."""
-        if (caps := getattr(self, "_capabilities", None)) is None:
-            caps = self._compute_capabilities()
-            object.__setattr__(self, "_capabilities", caps)
-        return caps
 
     @state_property
     def current_channel_position(self) -> int:
@@ -174,6 +166,11 @@ class CustomDpCover(PositionMixin, CustomDataPoint):
         if self._dp_direction.value is not None:
             return str(self._dp_direction.value) == _CoverActivity.OPENING
         return None
+
+    @info_property(cached=True)
+    def capabilities(self) -> CoverCapabilities:
+        """Return the cover capabilities."""
+        return self._compute_capabilities()
 
     @bind_collector
     async def close(self, *, collector: CallParameterCollector | None = None) -> None:
@@ -564,7 +561,7 @@ class CustomDpIpBlind(CustomDpBlind):
     _dp_combined = DataPointField(field=Field.COMBINED_PARAMETER, dpt=DpActionString)
     _dp_operation_mode: Final = DataPointField(field=Field.OPERATION_MODE, dpt=DpSelect)
 
-    @property
+    @state_property
     def operation_mode(self) -> str | None:
         """Return operation mode of cover."""
         val = self._dp_operation_mode.value
@@ -588,7 +585,7 @@ class CustomDpIpBlind(CustomDpBlind):
 class CustomDpGarage(PositionMixin, CustomDataPoint):
     """Class for Homematic garage data point."""
 
-    __slots__ = ("_capabilities",)
+    __slots__ = ("_cached_capabilities",)
 
     _category = DataPointCategory.COVER
 
@@ -596,14 +593,6 @@ class CustomDpGarage(PositionMixin, CustomDataPoint):
     _dp_door_command: Final = DataPointField(field=Field.DOOR_COMMAND, dpt=DpActionSelect)
     _dp_door_state: Final = DataPointField(field=Field.DOOR_STATE, dpt=DpSensor[str | None])
     _dp_section: Final = DataPointField(field=Field.SECTION, dpt=DpSensor[int | None])
-
-    @property
-    def capabilities(self) -> CoverCapabilities:
-        """Return the cover capabilities."""
-        if (caps := getattr(self, "_capabilities", None)) is None:
-            caps = self._compute_capabilities()
-            object.__setattr__(self, "_capabilities", caps)
-        return caps
 
     @state_property
     def current_position(self) -> int | None:
@@ -636,6 +625,11 @@ class CustomDpGarage(PositionMixin, CustomDataPoint):
         if self._dp_section.value is not None:
             return int(self._dp_section.value) == _GarageDoorActivity.OPENING
         return None
+
+    @info_property(cached=True)
+    def capabilities(self) -> CoverCapabilities:
+        """Return the cover capabilities."""
+        return self._compute_capabilities()
 
     @bind_collector
     async def close(self, *, collector: CallParameterCollector | None = None) -> None:

--- a/aiohomematic/model/custom/light.py
+++ b/aiohomematic/model/custom/light.py
@@ -22,7 +22,7 @@ from aiohomematic.model.custom.mixins import BrightnessMixin, StateChangeArgs, S
 from aiohomematic.model.custom.registry import DeviceConfig, DeviceProfileRegistry, ExtendedDeviceConfig
 from aiohomematic.model.data_point import CallParameterCollector, bind_collector
 from aiohomematic.model.generic import DpActionSelect, DpFloat, DpInteger, DpSelect, DpSensor, GenericDataPointAny
-from aiohomematic.property_decorators import DelegatedProperty, Kind, state_property
+from aiohomematic.property_decorators import DelegatedProperty, Kind, info_property, state_property
 
 # Activity states indicating LED is active
 _ACTIVITY_STATES_ACTIVE: Final[frozenset[str]] = frozenset({"UP", "DOWN"})
@@ -221,7 +221,7 @@ class SoundPlayerLedOnArgs(LightOnArgs, total=False):
 class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint):
     """Base class for Homematic light data point."""
 
-    __slots__ = ("_capabilities",)
+    __slots__ = ("_cached_capabilities",)
 
     _category = DataPointCategory.LIGHT
 
@@ -232,48 +232,6 @@ class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint):
     _dp_ramp_time = CombinedTimerField(value_field=Field.RAMP_TIME_VALUE)
 
     @property
-    def brightness_pct(self) -> int | None:
-        """Return the brightness in percent of this light."""
-        return self.level_to_brightness_pct(self._dp_level.value or _MIN_BRIGHTNESS)
-
-    @property
-    def capabilities(self) -> LightCapabilities:
-        """Return the light capabilities."""
-        if (caps := getattr(self, "_capabilities", None)) is None:
-            caps = self._compute_capabilities()
-            object.__setattr__(self, "_capabilities", caps)
-        return caps
-
-    @property
-    def group_brightness(self) -> int | None:
-        """Return the group brightness of this light between min/max brightness."""
-        if self._dp_group_level.value is not None:
-            return self.level_to_brightness(self._dp_group_level.value)
-        return None
-
-    @property
-    def group_brightness_pct(self) -> int | None:
-        """Return the group brightness in percent of this light."""
-        if self._dp_group_level.value is not None:
-            return self.level_to_brightness_pct(self._dp_group_level.value)
-        return None
-
-    @property
-    def has_color_temperature(self) -> bool:
-        """Return True if light currently has color temperature."""
-        return self.color_temp_kelvin is not None
-
-    @property
-    def has_effects(self) -> bool:
-        """Return True if light currently has effects."""
-        return self.effects is not None and len(self.effects) > 0
-
-    @property
-    def has_hs_color(self) -> bool:
-        """Return True if light currently has hs color."""
-        return self.hs_color is not None
-
-    @property
     def last_level(self) -> float | None:
         """Return the last non-default level value."""
         return self._dp_level.last_non_default_value
@@ -282,6 +240,11 @@ class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint):
     def brightness(self) -> int | None:
         """Return the brightness of this light between min/max brightness."""
         return self.level_to_brightness(self._dp_level.value or _MIN_BRIGHTNESS)
+
+    @state_property
+    def brightness_pct(self) -> int | None:
+        """Return the brightness in percent of this light."""
+        return self.level_to_brightness_pct(self._dp_level.value or _MIN_BRIGHTNESS)
 
     @state_property
     def color_temp_kelvin(self) -> int | None:
@@ -299,6 +262,35 @@ class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint):
         return None
 
     @state_property
+    def group_brightness(self) -> int | None:
+        """Return the group brightness of this light between min/max brightness."""
+        if self._dp_group_level.value is not None:
+            return self.level_to_brightness(self._dp_group_level.value)
+        return None
+
+    @state_property
+    def group_brightness_pct(self) -> int | None:
+        """Return the group brightness in percent of this light."""
+        if self._dp_group_level.value is not None:
+            return self.level_to_brightness_pct(self._dp_group_level.value)
+        return None
+
+    @state_property
+    def has_color_temperature(self) -> bool:
+        """Return True if light currently has color temperature."""
+        return self.color_temp_kelvin is not None
+
+    @state_property
+    def has_effects(self) -> bool:
+        """Return True if light currently has effects."""
+        return self.effects is not None and len(self.effects) > 0
+
+    @state_property
+    def has_hs_color(self) -> bool:
+        """Return True if light currently has hs color."""
+        return self.hs_color is not None
+
+    @state_property
     def hs_color(self) -> tuple[float, float] | None:
         """Return the hue and saturation color value [float, float]."""
         return None
@@ -307,6 +299,11 @@ class CustomDpDimmer(StateChangeTimerMixin, BrightnessMixin, CustomDataPoint):
     def is_on(self) -> bool | None:
         """Return true if dimmer is on."""
         return self._dp_level.value is not None and self._dp_level.value > _DIMMER_OFF
+
+    @info_property(cached=True)
+    def capabilities(self) -> LightCapabilities:
+        """Return the light capabilities."""
+        return self._compute_capabilities()
 
     @override
     def is_state_change(self, **kwargs: Unpack[StateChangeArgs]) -> bool:
@@ -529,28 +526,6 @@ class CustomDpIpRGBWLight(CustomDpDimmer):
         return (self._dp_level,)
 
     @property
-    def has_color_temperature(self) -> bool:
-        """Return True if light currently has color temperature (mode-dependent)."""
-        return self._device_operation_mode == _DeviceOperationMode.TUNABLE_WHITE
-
-    @property
-    def has_effects(self) -> bool:
-        """Return True if light currently has effects (mode-dependent)."""
-        return (
-            self._device_operation_mode != _DeviceOperationMode.PWM
-            and self.effects is not None
-            and len(self.effects) > 0
-        )
-
-    @property
-    def has_hs_color(self) -> bool:
-        """Return True if light currently has hs color (mode-dependent)."""
-        return self._device_operation_mode in (
-            _DeviceOperationMode.RGBW,
-            _DeviceOperationMode.RGB,
-        )
-
-    @property
     def usage(self) -> DataPointUsage:
         """
         Return the data_point usage.
@@ -575,6 +550,28 @@ class CustomDpIpRGBWLight(CustomDpDimmer):
     def effects(self) -> tuple[str, ...] | None:
         """Return the supported effects."""
         return self._dp_effect.values or ()
+
+    @state_property
+    def has_color_temperature(self) -> bool:
+        """Return True if light currently has color temperature (mode-dependent)."""
+        return self._device_operation_mode == _DeviceOperationMode.TUNABLE_WHITE
+
+    @state_property
+    def has_effects(self) -> bool:
+        """Return True if light currently has effects (mode-dependent)."""
+        return (
+            self._device_operation_mode != _DeviceOperationMode.PWM
+            and self.effects is not None
+            and len(self.effects) > 0
+        )
+
+    @state_property
+    def has_hs_color(self) -> bool:
+        """Return True if light currently has hs color (mode-dependent)."""
+        return self._device_operation_mode in (
+            _DeviceOperationMode.RGBW,
+            _DeviceOperationMode.RGB,
+        )
 
     @state_property
     def hs_color(self) -> tuple[float, float] | None:
@@ -679,10 +676,10 @@ class CustomDpIpFixedColorLight(CustomDpDimmer):
 
     _effect_list: tuple[str, ...]
 
-    channel_color_name: Final = DelegatedProperty[str | None](path="_dp_channel_color.value")
+    channel_color_name: Final = DelegatedProperty[str | None](path="_dp_channel_color.value", kind=Kind.STATE)
     effects: Final = DelegatedProperty[tuple[str, ...] | None](path="_effect_list", kind=Kind.STATE)
 
-    @property
+    @state_property
     def channel_hs_color(self) -> tuple[float, float] | None:
         """Return the channel hue and saturation color value [float, float]."""
         if self._dp_channel_color.value is not None:

--- a/aiohomematic/model/custom/lock.py
+++ b/aiohomematic/model/custom/lock.py
@@ -20,7 +20,7 @@ from aiohomematic.model.custom.field import DataPointField
 from aiohomematic.model.custom.registry import DeviceConfig, DeviceProfileRegistry, ExtendedDeviceConfig
 from aiohomematic.model.data_point import CallParameterCollector, bind_collector
 from aiohomematic.model.generic import DpAction, DpActionSelect, DpSensor, DpSwitch
-from aiohomematic.property_decorators import state_property
+from aiohomematic.property_decorators import info_property, state_property
 
 
 @unique
@@ -61,18 +61,10 @@ class LockState(StrEnum):
 class BaseCustomDpLock(CustomDataPoint):
     """Class for HomematicIP lock data point."""
 
-    __slots__ = ("_capabilities",)
+    __slots__ = ("_cached_capabilities",)
 
     _category = DataPointCategory.LOCK
     _ignore_multiple_channels_for_name = True
-
-    @property
-    def capabilities(self) -> LockCapabilities:
-        """Return the lock capabilities."""
-        if (caps := getattr(self, "_capabilities", None)) is None:
-            caps = self._compute_capabilities()
-            object.__setattr__(self, "_capabilities", caps)
-        return caps
 
     @state_property
     def is_jammed(self) -> bool:
@@ -93,6 +85,11 @@ class BaseCustomDpLock(CustomDataPoint):
     def is_unlocking(self) -> bool | None:
         """Return true if the lock is unlocking."""
         return None
+
+    @info_property(cached=True)
+    def capabilities(self) -> LockCapabilities:
+        """Return the lock capabilities."""
+        return self._compute_capabilities()
 
     @abstractmethod
     @bind_collector(priority=CommandPriority.CRITICAL)

--- a/aiohomematic/model/custom/siren.py
+++ b/aiohomematic/model/custom/siren.py
@@ -23,7 +23,7 @@ from aiohomematic.model.custom.field import DataPointField
 from aiohomematic.model.custom.registry import DeviceProfileRegistry
 from aiohomematic.model.data_point import CallParameterCollector, bind_collector
 from aiohomematic.model.generic import DpActionFloat, DpActionSelect, DpBinarySensor, DpSelect, DpSensor
-from aiohomematic.property_decorators import DelegatedProperty, Kind, state_property
+from aiohomematic.property_decorators import DelegatedProperty, Kind, info_property, state_property
 
 _SMOKE_DETECTOR_ALARM_STATUS_IDLE_OFF: Final = "IDLE_OFF"
 
@@ -92,17 +92,9 @@ class PlaySoundArgs(TypedDict, total=False):
 class BaseCustomDpSiren(CustomDataPoint):
     """Class for Homematic siren data point."""
 
-    __slots__ = ("_capabilities",)
+    __slots__ = ("_cached_capabilities",)
 
     _category = DataPointCategory.SIREN
-
-    @property
-    def capabilities(self) -> SirenCapabilities:
-        """Return the siren capabilities."""
-        if (caps := getattr(self, "_capabilities", None)) is None:
-            caps = self._compute_capabilities()
-            object.__setattr__(self, "_capabilities", caps)
-        return caps
 
     @state_property
     @abstractmethod
@@ -118,6 +110,11 @@ class BaseCustomDpSiren(CustomDataPoint):
     @abstractmethod
     def is_on(self) -> bool:
         """Return true if siren is on."""
+
+    @info_property(cached=True)
+    def capabilities(self) -> SirenCapabilities:
+        """Return the siren capabilities."""
+        return self._compute_capabilities()
 
     @abstractmethod
     @bind_collector(priority=CommandPriority.CRITICAL)

--- a/aiohomematic/model/custom/text_display.py
+++ b/aiohomematic/model/custom/text_display.py
@@ -116,7 +116,7 @@ class CustomDpTextDisplay(CustomDataPoint):
     available_text_colors: Final = DelegatedProperty[tuple[str, ...] | None](
         path="_dp_display_data_text_color.values", kind=Kind.STATE
     )
-    burst_limit_warning: Final = DelegatedProperty[bool](path="_dp_burst_limit_warning.value")
+    burst_limit_warning: Final = DelegatedProperty[bool](path="_dp_burst_limit_warning.value", kind=Kind.STATE)
 
     @state_property
     def has_icons(self) -> bool:

--- a/aiohomematic/model/data_point.py
+++ b/aiohomematic/model/data_point.py
@@ -99,7 +99,9 @@ from aiohomematic.const import (
     ParameterType,
     ParamsetKey,
     ProductGroup,
+    Quantity,
     ServiceScope,
+    ValueBehavior,
     check_ignore_parameter_on_initial_load,
 )
 from aiohomematic.context import (
@@ -126,6 +128,13 @@ from aiohomematic.interfaces import (
     TaskSchedulerProtocol,
 )
 from aiohomematic.interfaces.client import ValueAndParamsetOperationsProtocol
+from aiohomematic.model.data_point_metadata import (
+    get_binary_sensor_quantity_by_device_and_param,
+    get_binary_sensor_quantity_by_param,
+    get_quantity_metadata_by_device_and_param,
+    get_quantity_metadata_by_param,
+    get_quantity_metadata_by_unit,
+)
 from aiohomematic.model.optimistic import OptimisticValueTracker
 from aiohomematic.model.support import (
     DataPointNameData,
@@ -760,6 +769,8 @@ class BaseParameterDataPoint[
 
     __slots__ = (
         "_cached__enabled_by_channel_operation_mode",
+        "_cached_quantity",
+        "_cached_value_behavior",
         "_current_value",
         "_default",
         "_description",
@@ -1065,10 +1076,58 @@ class BaseParameterDataPoint[
             self._client.last_value_send_tracker.get_last_value_send(dpk=self.dpk),
         )
 
+    @config_property(cached=True)
+    def quantity(self) -> Quantity | None:
+        """
+        Return the semantic quantity of this data point.
+
+        Describes what physical or logical quantity the data point measures
+        (e.g., temperature, humidity, voltage). Resolved from parameter name,
+        device model, or unit.
+        """
+        device_model = self._device.model if hasattr(self, "_device") else ""
+
+        # For binary sensors, use dedicated lookup
+        if self.category == DataPointCategory.BINARY_SENSOR:
+            if q := get_binary_sensor_quantity_by_device_and_param(
+                device_model=device_model, parameter=self._parameter
+            ):
+                return q
+            return get_binary_sensor_quantity_by_param(parameter=self._parameter)
+
+        # For sensors/numbers: try device+param override first, then param, then unit fallback
+        if metadata := get_quantity_metadata_by_device_and_param(device_model=device_model, parameter=self._parameter):
+            return metadata.quantity
+        if metadata := get_quantity_metadata_by_param(parameter=self._parameter):
+            return metadata.quantity
+        if self._unit and (metadata := get_quantity_metadata_by_unit(unit=self._unit)):
+            return metadata.quantity
+        return None
+
     @config_property
     def unique_id(self) -> str:
         """Return the unique_id."""
         return f"{self._unique_id}_{DataPointCategory.SENSOR}" if self._is_forced_sensor else self._unique_id
+
+    @config_property(cached=True)
+    def value_behavior(self) -> ValueBehavior | None:
+        """
+        Return the value behavior of this data point.
+
+        Describes how the numeric value behaves over time:
+        - INSTANTANEOUS: Point-in-time reading (temperature, voltage)
+        - CUMULATIVE: Running total that may reset (energy counter)
+        - MONOTONIC: Running total that only increases (lifetime consumption)
+        """
+        device_model = self._device.model if hasattr(self, "_device") else ""
+
+        if metadata := get_quantity_metadata_by_device_and_param(device_model=device_model, parameter=self._parameter):
+            return metadata.value_behavior
+        if metadata := get_quantity_metadata_by_param(parameter=self._parameter):
+            return metadata.value_behavior
+        if self._unit and (metadata := get_quantity_metadata_by_unit(unit=self._unit)):
+            return metadata.value_behavior
+        return None
 
     @hm_property(cached=True)
     def _enabled_by_channel_operation_mode(self) -> bool | None:

--- a/aiohomematic/model/data_point_metadata.py
+++ b/aiohomematic/model/data_point_metadata.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Metadata mappings for Homematic data points.
+
+Maps Homematic parameters to their semantic quantity and value behavior.
+This is Homematic domain knowledge, independent of any smart home platform.
+
+Public API of this module is defined by __all__.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Final, NamedTuple
+
+from aiohomematic.const import Quantity, ValueBehavior
+
+__all__ = [
+    "QuantityMetadata",
+    "get_binary_sensor_quantity_by_device_and_param",
+    "get_quantity_metadata_by_device_and_param",
+    "get_quantity_metadata_by_param",
+    "get_quantity_metadata_by_unit",
+]
+
+
+class QuantityMetadata(NamedTuple):
+    """Metadata for a data point's semantic classification."""
+
+    quantity: Quantity | None = None
+    value_behavior: ValueBehavior | None = None
+
+
+# ---------------------------------------------------------------------------
+# Sensor: parameter → (quantity, value_behavior)
+# ---------------------------------------------------------------------------
+
+_SENSOR_METADATA_BY_PARAM: Final[Mapping[str | tuple[str, ...], QuantityMetadata]] = {
+    "AIR_PRESSURE": QuantityMetadata(
+        quantity=Quantity.PRESSURE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "BRIGHTNESS": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "CARRIER_SENSE_LEVEL": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "CONCENTRATION": QuantityMetadata(
+        quantity=Quantity.CO2,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "CURRENT": QuantityMetadata(
+        quantity=Quantity.CURRENT,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "DEWPOINT": QuantityMetadata(
+        quantity=Quantity.TEMPERATURE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    ("ACTIVITY_STATE", "DIRECTION"): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    "DOOR_STATE": QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    "DUTY_CYCLE_LEVEL": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "ENERGY_COUNTER": QuantityMetadata(
+        quantity=Quantity.ENERGY,
+        value_behavior=ValueBehavior.MONOTONIC,
+    ),
+    "FILLING_LEVEL": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "FREQUENCY": QuantityMetadata(
+        quantity=Quantity.FREQUENCY,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "GAS_ENERGY_COUNTER": QuantityMetadata(
+        quantity=Quantity.GAS,
+        value_behavior=ValueBehavior.MONOTONIC,
+    ),
+    "GAS_FLOW": QuantityMetadata(
+        quantity=Quantity.VOLUME_FLOW_RATE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "GAS_VOLUME": QuantityMetadata(
+        quantity=Quantity.GAS,
+        value_behavior=ValueBehavior.MONOTONIC,
+    ),
+    ("HUMIDITY", "ACTUAL_HUMIDITY"): QuantityMetadata(
+        quantity=Quantity.HUMIDITY,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "IEC_ENERGY_COUNTER": QuantityMetadata(
+        quantity=Quantity.ENERGY,
+        value_behavior=ValueBehavior.MONOTONIC,
+    ),
+    "IEC_POWER": QuantityMetadata(
+        quantity=Quantity.POWER,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    (
+        "ILLUMINATION",
+        "AVERAGE_ILLUMINATION",
+        "CURRENT_ILLUMINATION",
+        "HIGHEST_ILLUMINATION",
+        "LOWEST_ILLUMINATION",
+        "LUX",
+    ): QuantityMetadata(
+        quantity=Quantity.ILLUMINANCE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    ("LEVEL", "LEVEL_2"): QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "LOCK_STATE": QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    (
+        "MASS_CONCENTRATION_PM_1",
+        "MASS_CONCENTRATION_PM_1_24H_AVERAGE",
+    ): QuantityMetadata(
+        quantity=Quantity.PM1,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    (
+        "MASS_CONCENTRATION_PM_10",
+        "MASS_CONCENTRATION_PM_10_24H_AVERAGE",
+    ): QuantityMetadata(
+        quantity=Quantity.PM10,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    (
+        "MASS_CONCENTRATION_PM_2_5",
+        "MASS_CONCENTRATION_PM_2_5_24H_AVERAGE",
+    ): QuantityMetadata(
+        quantity=Quantity.PM25,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "NUMBER_CONCENTRATION_PM_1": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "NUMBER_CONCENTRATION_PM_10": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "NUMBER_CONCENTRATION_PM_2_5": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "TYPICAL_PARTICLE_SIZE": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    ("BATTERY_STATE", "OPERATING_VOLTAGE"): QuantityMetadata(
+        quantity=Quantity.VOLTAGE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "POWER": QuantityMetadata(
+        quantity=Quantity.POWER,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "RAIN_COUNTER": QuantityMetadata(
+        value_behavior=ValueBehavior.MONOTONIC,
+    ),
+    ("RSSI_DEVICE", "RSSI_PEER"): QuantityMetadata(
+        quantity=Quantity.SIGNAL_STRENGTH,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    ("ACTUAL_TEMPERATURE", "TEMPERATURE"): QuantityMetadata(
+        quantity=Quantity.TEMPERATURE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "SMOKE_DETECTOR_ALARM_STATUS": QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    "SUNSHINEDURATION": QuantityMetadata(
+        value_behavior=ValueBehavior.MONOTONIC,
+    ),
+    "VALUE": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "VAPOR_CONCENTRATION": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "VOLTAGE": QuantityMetadata(
+        quantity=Quantity.VOLTAGE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    (
+        "WIND_DIR",
+        "WIND_DIR_RANGE",
+        "WIND_DIRECTION",
+        "WIND_DIRECTION_RANGE",
+    ): QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "WIND_SPEED": QuantityMetadata(
+        quantity=Quantity.WIND_SPEED,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Sensor: (device_model, parameter) → (quantity, value_behavior) overrides
+# ---------------------------------------------------------------------------
+
+_SENSOR_METADATA_BY_DEVICE_AND_PARAM: Final[Mapping[tuple[str | tuple[str, ...], str], QuantityMetadata]] = {
+    ("HmIP-WKP", "CODE_STATE"): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    (
+        ("HmIP-SRH", "HM-Sec-RHS", "HM-Sec-xx", "ZEL STG RM FDK"),
+        "STATE",
+    ): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    ("HM-Sec-Win", "STATUS"): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    ("HM-Sec-Win", "DIRECTION"): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    ("HM-Sec-Win", "ERROR"): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    ("HM-Sec-Key", "DIRECTION"): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    ("HM-Sec-Key", "ERROR"): QuantityMetadata(
+        quantity=Quantity.ENUM,
+    ),
+    (("HM-CC-RT-DN", "HM-CC-VD"), "VALVE_STATE"): QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Sensor: unit → (quantity, value_behavior) fallback
+# ---------------------------------------------------------------------------
+
+_SENSOR_METADATA_BY_UNIT: Final[Mapping[str, QuantityMetadata]] = {
+    "%": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "bar": QuantityMetadata(
+        quantity=Quantity.PRESSURE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "°C": QuantityMetadata(
+        quantity=Quantity.TEMPERATURE,
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+    "g/m³": QuantityMetadata(
+        value_behavior=ValueBehavior.INSTANTANEOUS,
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Binary sensor: parameter → quantity
+# ---------------------------------------------------------------------------
+
+_BINARY_SENSOR_QUANTITY_BY_PARAM: Final[Mapping[str | tuple[str, ...], Quantity]] = {
+    "ALARMSTATE": Quantity.SAFETY,
+    "ACOUSTIC_ALARM_ACTIVE": Quantity.SAFETY,
+    ("BLOCKED_PERMANENT", "BLOCKED_TEMPORARY"): Quantity.PROBLEM,
+    "BURST_LIMIT_WARNING": Quantity.PROBLEM,
+    ("DUTYCYCLE", "DUTY_CYCLE"): Quantity.PROBLEM,
+    "DEW_POINT_ALARM": Quantity.PROBLEM,
+    "EMERGENCY_OPERATION": Quantity.SAFETY,
+    "ERROR_JAMMED": Quantity.PROBLEM,
+    "HEATER_STATE": Quantity.HEAT,
+    ("LOWBAT", "LOW_BAT", "LOWBAT_SENSOR"): Quantity.BATTERY,
+    "MOISTURE_DETECTED": Quantity.MOISTURE,
+    "MOTION": Quantity.MOTION,
+    "OPTICAL_ALARM_ACTIVE": Quantity.SAFETY,
+    "POWER_MAINS_FAILURE": Quantity.PROBLEM,
+    "PRESENCE_DETECTION_STATE": Quantity.PRESENCE,
+    ("PROCESS", "WORKING"): Quantity.RUNNING,
+    "RAINING": Quantity.MOISTURE,
+    ("SABOTAGE", "SABOTAGE_STICKY"): Quantity.TAMPER,
+    "WATERLEVEL_DETECTED": Quantity.MOISTURE,
+    "WINDOW_STATE": Quantity.WINDOW,
+}
+
+# ---------------------------------------------------------------------------
+# Binary sensor: (device_model, parameter) → quantity overrides
+# ---------------------------------------------------------------------------
+
+_BINARY_SENSOR_QUANTITY_BY_DEVICE_AND_PARAM: Final[Mapping[tuple[str | tuple[str, ...], str], Quantity]] = {
+    ("HmIP-DSD-PCB", "STATE"): Quantity.OCCUPANCY,
+    (("HmIP-SCI", "HmIP-FCI1", "HmIP-FCI6"), "STATE"): Quantity.OPENING,
+    ("HM-Sec-SD", "STATE"): Quantity.SMOKE,
+    (
+        (
+            "HmIP-SWD",
+            "HmIP-SWDO",
+            "HmIP-SWDM",
+            "HM-Sec-SC",
+            "HM-SCI-3-FM",
+            "ZEL STG RM FFK",
+        ),
+        "STATE",
+    ): Quantity.WINDOW,
+    ("HM-Sen-RD-O", "STATE"): Quantity.MOISTURE,
+    ("HM-Sec-Win", "WORKING"): Quantity.RUNNING,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public lookup functions
+# ---------------------------------------------------------------------------
+
+
+def _param_matches(*, params: str | tuple[str, ...], parameter: str) -> bool:
+    """Check if a parameter matches a key (single string or tuple)."""
+    if isinstance(params, str):
+        return parameter.upper() == params.upper()
+    return any(parameter.upper() == p.upper() for p in params)
+
+
+def _model_matches(*, models: str | tuple[str, ...], device_model: str) -> bool:
+    """Check if a device model matches (prefix match)."""
+    if isinstance(models, str):
+        return device_model.upper().startswith(models.upper())
+    return any(device_model.upper().startswith(m.upper()) for m in models)
+
+
+def get_quantity_metadata_by_param(*, parameter: str) -> QuantityMetadata | None:
+    """Look up quantity metadata for a sensor parameter."""
+    for params, metadata in _SENSOR_METADATA_BY_PARAM.items():
+        if _param_matches(params=params, parameter=parameter):
+            return metadata
+    return None
+
+
+def get_quantity_metadata_by_device_and_param(*, device_model: str, parameter: str) -> QuantityMetadata | None:
+    """Look up quantity metadata by device model and parameter (overrides)."""
+    for (models, param), metadata in _SENSOR_METADATA_BY_DEVICE_AND_PARAM.items():
+        if param.upper() == parameter.upper() and _model_matches(models=models, device_model=device_model):
+            return metadata
+    return None
+
+
+def get_quantity_metadata_by_unit(*, unit: str) -> QuantityMetadata | None:
+    """Look up quantity metadata by unit (fallback)."""
+    return _SENSOR_METADATA_BY_UNIT.get(unit)
+
+
+def get_binary_sensor_quantity_by_device_and_param(*, device_model: str, parameter: str) -> Quantity | None:
+    """Look up binary sensor quantity by device model and parameter (overrides)."""
+    for (models, param), quantity in _BINARY_SENSOR_QUANTITY_BY_DEVICE_AND_PARAM.items():
+        if param.upper() == parameter.upper() and _model_matches(models=models, device_model=device_model):
+            return quantity
+    return None
+
+
+def get_binary_sensor_quantity_by_param(*, parameter: str) -> Quantity | None:
+    """Look up binary sensor quantity by parameter."""
+    for params, quantity in _BINARY_SENSOR_QUANTITY_BY_PARAM.items():
+        if _param_matches(params=params, parameter=parameter):
+            return quantity
+    return None

--- a/aiohomematic/model/week_profile.py
+++ b/aiohomematic/model/week_profile.py
@@ -390,7 +390,7 @@ from aiohomematic.model.schedule_models import (
     convert_raw_group_to_simple_entry,
     convert_simple_entry_to_raw_group,
 )
-from aiohomematic.property_decorators import DelegatedProperty
+from aiohomematic.property_decorators import DelegatedProperty, Kind
 
 if TYPE_CHECKING:
     from aiohomematic.model.custom import BaseCustomDpClimate
@@ -1000,8 +1000,8 @@ class ClimateWeekProfile(WeekProfile[ClimateSchedule]):
         # Cast to ClimateScheduleDictInternal since we built it with all required keys
         return cast(_ClimateScheduleDictInternal, schedule_data)
 
-    max_temp: Final = DelegatedProperty[float](path="_max_temp")
-    min_temp: Final = DelegatedProperty[float](path="_min_temp")
+    max_temp: Final = DelegatedProperty[float](path="_max_temp", kind=Kind.CONFIG)
+    min_temp: Final = DelegatedProperty[float](path="_min_temp", kind=Kind.CONFIG)
 
     @property
     def available_profiles(self) -> tuple[ScheduleProfile, ...]:

--- a/aiohomematic/property_decorators.py
+++ b/aiohomematic/property_decorators.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 import contextlib
+import dataclasses
 from datetime import datetime
 from enum import Enum, StrEnum, unique
 from functools import singledispatch
@@ -645,7 +646,7 @@ def get_hm_property_by_kind(*, data_object: Any, kind: Kind, context: bool = Fal
             if isinstance(value, LogContextProtocol):
                 result.update({f"{name[:1]}.{k}": v for k, v in value.log_context.items()})
             else:
-                result[name] = _get_text_value(value)
+                result[name] = _get_text_value_with_dataclass_fallback(value=value)
         except Exception:
             # Avoid propagating side effects/errors from getters
             result[name] = None
@@ -696,6 +697,15 @@ def _get_text_value_enum(value: Enum) -> str:  # kwonly: disable
 def _get_text_value_datetime(value: datetime) -> float:  # kwonly: disable
     """Convert datetime to unix timestamp."""
     return datetime.timestamp(value)
+
+
+def _get_text_value_with_dataclass_fallback(*, value: Any) -> Any:
+    """Normalize value, converting dataclass instances to dicts."""
+    result = _get_text_value(value)
+    # If singledispatch returned unchanged and it's a dataclass, convert to dict
+    if result is value and dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {k: _get_text_value(v) for k, v in dataclasses.asdict(value).items()}
+    return result
 
 
 def get_hm_property_by_log_context(*, data_object: Any) -> Mapping[str, Any]:

--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,40 @@
 
 ### Added
 
+- **Data point metadata**: Introduced `Quantity` and `ValueBehavior` enums in
+  `const.py` and a new `data_point_metadata.py` module that maps Homematic
+  parameters to their semantic quantity (e.g., temperature, humidity, energy)
+  and value behavior (instantaneous, cumulative, monotonic). The `quantity` and
+  `value_behavior` properties are now available on `BaseParameterDataPoint`.
 - **Cover capabilities**: Introduced `CoverCapabilities` dataclass with static
   capability flags (`position`, `tilt`, `stop`, `vent`) for cover entities,
   consistent with the existing capabilities pattern used by Light, Climate, Lock,
   and Siren. Predefined capability sets: `COVER_CAPABILITIES`,
   `BLIND_CAPABILITIES`, `GARAGE_CAPABILITIES`. This replaces the need for
   `isinstance()` checks to determine cover features.
+- **Cover device documentation**: Added detailed documentation for cover device
+  types, capabilities, and garage door specifics including discrete state
+  mapping and position slider behavior.
+
+### Changed
+
+- **Capabilities use `info_property(cached=True)`**: Replaced manual
+  `getattr`/`object.__setattr__` caching pattern in `capabilities` properties
+  across Climate, Light, Lock, and Siren with the declarative
+  `@info_property(cached=True)` decorator. The `_capabilities` slot has been
+  renamed to `_cached_capabilities` accordingly.
+- **Property decorator improvements**: `config_property` and `info_property`
+  now support a `cached=True` parameter for lazy-computed immutable values.
+  Dataclass instances in log context are automatically converted to dicts.
+- **Light property categorization**: Reclassified `brightness_pct`,
+  `group_brightness`, `group_brightness_pct`, and other light properties from
+  plain `@property` to `@state_property` for proper state tracking.
+- **Climate temperature bounds**: `min_temp` and `max_temp` in
+  `BaseCustomDpClimate` changed from `@state_property` to `@config_property`
+  since temperature bounds are configuration values, not runtime state.
+- **DelegatedProperty kind annotations**: Added `Kind.CONFIG`/`Kind.STATE`
+  annotations to `ClimateWeekProfile.max_temp`/`min_temp` and
+  `CustomDpTextDisplay.burst_limit_warning`.
 
 # Version 2026.3.4 (2026-03-08)
 

--- a/docs/user/device_support.md
+++ b/docs/user/device_support.md
@@ -64,14 +64,14 @@ Cover devices are mapped to the Home Assistant `cover` platform. Different devic
 
 ### Cover Types and Capabilities
 
-| Device Type | Class | position | tilt | stop | vent | HA device_class |
-| --- | --- | --- | --- | --- | --- | --- |
-| RF Shutters (HM-LC-Bl1-*) | `CustomDpCover` | yes | no | yes | no | `shutter` |
-| IP Shutters (HmIP-BROLL, HmIP-FROLL) | `CustomDpCover` | yes | no | yes | no | `shutter` |
-| RF Blinds (HM-LC-Ja1PBU-FM) | `CustomDpBlind` | yes | yes | yes | no | `blind` |
-| IP Blinds (HmIP-BBL, HmIP-FBL, HmIP-DRBLI4) | `CustomDpIpBlind` | yes | yes | yes | no | `blind` |
-| Window Drive (HM-Sec-Win) | `CustomDpWindowDrive` | yes | no | yes | no | `window` |
-| Garage Door (HmIP-MOD-HO, HmIP-MOD-TM) | `CustomDpGarage` | yes | no | yes | yes | `garage` |
+| Device Type                                 | Class                 | position | tilt | stop | vent | HA device_class |
+| ------------------------------------------- | --------------------- | -------- | ---- | ---- | ---- | --------------- |
+| RF Shutters (HM-LC-Bl1-\*)                  | `CustomDpCover`       | yes      | no   | yes  | no   | `shutter`       |
+| IP Shutters (HmIP-BROLL, HmIP-FROLL)        | `CustomDpCover`       | yes      | no   | yes  | no   | `shutter`       |
+| RF Blinds (HM-LC-Ja1PBU-FM)                 | `CustomDpBlind`       | yes      | yes  | yes  | no   | `blind`         |
+| IP Blinds (HmIP-BBL, HmIP-FBL, HmIP-DRBLI4) | `CustomDpIpBlind`     | yes      | yes  | yes  | no   | `blind`         |
+| Window Drive (HM-Sec-Win)                   | `CustomDpWindowDrive` | yes      | no   | yes  | no   | `window`        |
+| Garage Door (HmIP-MOD-HO, HmIP-MOD-TM)      | `CustomDpGarage`      | yes      | no   | yes  | yes  | `garage`        |
 
 ### Checking Capabilities
 
@@ -95,21 +95,21 @@ Garage doors (HmIP-MOD-HO, HmIP-MOD-TM) differ fundamentally from other cover ty
 
 **Discrete states instead of continuous position.** While shutters and blinds have a continuous position range (0-100%), garage doors only have three discrete states:
 
-| State | Mapped Position | Description |
-| --- | --- | --- |
-| CLOSED | 0 | Door fully closed |
-| VENTILATION_POSITION | 10 | Door slightly open for ventilation |
-| OPEN | 100 | Door fully open |
+| State                | Mapped Position | Description                        |
+| -------------------- | --------------- | ---------------------------------- |
+| CLOSED               | 0               | Door fully closed                  |
+| VENTILATION_POSITION | 10              | Door slightly open for ventilation |
+| OPEN                 | 100             | Door fully open                    |
 
 **Asymmetric read/write parameters.** The device state is read from `DOOR_STATE` and `SECTION`, while commands are sent to `DOOR_COMMAND`. The available commands are:
 
-| Command | Description |
-| --- | --- |
-| OPEN | Open the door |
-| CLOSE | Close the door |
+| Command      | Description                  |
+| ------------ | ---------------------------- |
+| OPEN         | Open the door                |
+| CLOSE        | Close the door               |
 | PARTIAL_OPEN | Move to ventilation position |
-| STOP | Stop movement |
-| NOP | No operation |
+| STOP         | Stop movement                |
+| NOP          | No operation                 |
 
 **Position slider behavior.** Because the Home Assistant cover platform has no native concept for a ventilation position, the garage door maps its three states to discrete position values (0/10/100). The position slider in the UI therefore has three effective zones:
 

--- a/tests/contract/test_property_decorator_contract.py
+++ b/tests/contract/test_property_decorator_contract.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""
+Contract tests for property decorator classification.
+
+STABILITY GUARANTEE
+-------------------
+These tests define the stable API contract for property decorator usage
+across model classes. Any reclassification that breaks these tests requires
+a MAJOR version bump since it changes payload structure for consumers
+(aiohomematic2mqtt, homematicip_local).
+
+The contract ensures that:
+1. state_payload contains only dynamic runtime values
+2. config_payload contains only static configuration
+3. info_payload contains only identification/metadata
+4. No property key appears in multiple payload categories
+5. Key consumer-facing properties are always present in expected payloads
+6. quantity and value_behavior are available on sensor data points
+
+See ADR for architectural context and rationale.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aiohomematic.const import DataPointCategory, Quantity, ValueBehavior
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+TEST_DEVICES: frozenset[str] = frozenset(
+    {
+        "VCU2128127",  # HmIP-eTRV (climate)
+        "VCU3609622",  # HmIP-eTRV-E (climate)
+        "VCU0000054",  # HmIP-BROLL (cover/shutter)
+        "VCU0000263",  # HmIP-BBL (cover/blind)
+        "VCU0000350",  # HmIP-BSL (light dimmer)
+        "VCU5765055",  # HmIP-SWSD (siren)
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Payload disjointedness: no key in multiple payload categories
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    (
+        "address_device_translation",
+        "do_mock_client",
+        "ignore_devices_on_create",
+        "un_ignore_list",
+    ),
+    [(TEST_DEVICES, True, None, None)],
+)
+async def test_payload_keys_are_disjoint(
+    central_client_factory_with_ccu_client,
+):
+    """Ensure no key appears in both state_payload and config_payload."""
+    central, *_ = central_client_factory_with_ccu_client
+    for device in central.devices:
+        for dp in device.generic_data_points.values():
+            state_keys = set(dp.state_payload.keys())
+            config_keys = set(dp.config_payload.keys())
+            info_keys = set(dp.info_payload.keys())
+
+            overlap_sc = state_keys & config_keys
+            overlap_si = state_keys & info_keys
+            overlap_ci = config_keys & info_keys
+
+            assert not overlap_sc, f"{dp.state_path}: keys in both state and config: {overlap_sc}"
+            assert not overlap_si, f"{dp.state_path}: keys in both state and info: {overlap_si}"
+            assert not overlap_ci, f"{dp.state_path}: keys in both config and info: {overlap_ci}"
+
+
+# ---------------------------------------------------------------------------
+# Classification invariants: specific properties in correct payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    (
+        "address_device_translation",
+        "do_mock_client",
+        "ignore_devices_on_create",
+        "un_ignore_list",
+    ),
+    [(TEST_DEVICES, True, None, None)],
+)
+async def test_min_max_temp_are_config_not_state(
+    central_client_factory_with_ccu_client,
+):
+    """min_temp and max_temp must be in config_payload, not state_payload."""
+    central, *_ = central_client_factory_with_ccu_client
+    for device in central.devices:
+        for dp in device.custom_data_points.values():
+            if dp.category == DataPointCategory.CLIMATE:
+                config_keys = set(dp.config_payload.keys())
+                state_keys = set(dp.state_payload.keys())
+
+                assert "min_temp" in config_keys, f"{dp}: min_temp missing from config_payload"
+                assert "max_temp" in config_keys, f"{dp}: max_temp missing from config_payload"
+                assert "min_temp" not in state_keys, f"{dp}: min_temp should not be in state_payload"
+                assert "max_temp" not in state_keys, f"{dp}: max_temp should not be in state_payload"
+
+
+# ---------------------------------------------------------------------------
+# Quantity and ValueBehavior on sensor data points
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    (
+        "address_device_translation",
+        "do_mock_client",
+        "ignore_devices_on_create",
+        "un_ignore_list",
+    ),
+    [(TEST_DEVICES, True, None, None)],
+)
+async def test_quantity_in_config_payload_for_known_sensors(
+    central_client_factory_with_ccu_client,
+):
+    """Quantity should appear in config_payload for data points with known parameters."""
+    central, *_ = central_client_factory_with_ccu_client
+    # Parameters that must have a quantity mapping
+    known_params = {
+        "ACTUAL_TEMPERATURE",
+        "HUMIDITY",
+        "OPERATING_VOLTAGE",
+        "ENERGY_COUNTER",
+        "POWER",
+        "VOLTAGE",
+        "CURRENT",
+        "RSSI_DEVICE",
+        "RSSI_PEER",
+        "LOW_BAT",
+        "LOWBAT",
+    }
+    for device in central.devices:
+        for dp in device.generic_data_points.values():
+            if dp.parameter in known_params:
+                config = dp.config_payload
+                assert "quantity" in config, f"{dp.state_path} ({dp.parameter}): quantity missing from config_payload"
+                assert config["quantity"] is not None, (
+                    f"{dp.state_path} ({dp.parameter}): quantity should not be None for known parameter"
+                )
+
+
+@pytest.mark.parametrize(
+    (
+        "address_device_translation",
+        "do_mock_client",
+        "ignore_devices_on_create",
+        "un_ignore_list",
+    ),
+    [(TEST_DEVICES, True, None, None)],
+)
+async def test_value_behavior_in_config_payload_for_known_sensors(
+    central_client_factory_with_ccu_client,
+):
+    """value_behavior should appear in config_payload for sensor data points."""
+    central, *_ = central_client_factory_with_ccu_client
+    # Parameters that must have value_behavior
+    measurement_params = {
+        "ACTUAL_TEMPERATURE",
+        "HUMIDITY",
+        "OPERATING_VOLTAGE",
+        "POWER",
+        "VOLTAGE",
+        "CURRENT",
+    }
+    counter_params = {"ENERGY_COUNTER"}
+
+    for device in central.devices:
+        for dp in device.generic_data_points.values():
+            if dp.parameter in measurement_params:
+                config = dp.config_payload
+                assert config.get("value_behavior") == ValueBehavior.INSTANTANEOUS, (
+                    f"{dp.state_path} ({dp.parameter}): expected INSTANTANEOUS, got {config.get('value_behavior')}"
+                )
+            elif dp.parameter in counter_params:
+                config = dp.config_payload
+                assert config.get("value_behavior") == ValueBehavior.MONOTONIC, (
+                    f"{dp.state_path} ({dp.parameter}): expected MONOTONIC, got {config.get('value_behavior')}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Quantity enum completeness
+# ---------------------------------------------------------------------------
+
+
+def test_quantity_enum_covers_essential_types():
+    """Verify Quantity enum includes all essential measurement types."""
+    essential = {
+        "temperature",
+        "humidity",
+        "voltage",
+        "current",
+        "power",
+        "energy",
+        "pressure",
+        "illuminance",
+        "signal_strength",
+        "wind_speed",
+        "battery",
+        "motion",
+        "smoke",
+        "window",
+    }
+    quantity_values = {q.value for q in Quantity}
+    missing = essential - quantity_values
+    assert not missing, f"Quantity enum missing essential types: {missing}"
+
+
+def test_value_behavior_enum_values():
+    """Verify ValueBehavior enum has exactly the expected values."""
+    assert set(ValueBehavior) == {
+        ValueBehavior.INSTANTANEOUS,
+        ValueBehavior.CUMULATIVE,
+        ValueBehavior.MONOTONIC,
+    }


### PR DESCRIPTION
Introduce semantic metadata for data points and refine property classifications.

- Add Quantity and ValueBehavior enums (const.py) and a new data_point_metadata.py module mapping Homematic parameters/units to semantic Quantity and ValueBehavior.
- Expose cached config properties quantity and value_behavior on BaseParameterDataPoint to provide platform-independent measurement semantics.
- Replace manual capabilities caching with @info_property(cached=True) (rename _capabilities -> _cached_capabilities) and annotate DelegatedProperty kinds (CONFIG/STATE) across climate, cover, light, lock, siren, text_display and week_profile.
- Improve property_decorators to convert dataclass instances in log context and support cached info/config properties.
- Update docs and changelog and add contract tests to enforce payload classification and metadata presence.