### PR TITLE
Use monotonic timestamps for event health checks

### DIFF
--- a/aiohomematic/central/coordinators/event.py
+++ b/aiohomematic/central/coordinators/event.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Mapping
 from datetime import datetime
 from functools import partial
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Final, TypedDict, Unpack
 
 from aiohomematic.interfaces import TaskSchedulerProtocol
@@ -128,6 +129,8 @@ class EventCoordinator(
 
         # Store last event seen datetime by interface_id
         self._last_event_seen_for_interface: Final[dict[str, datetime]] = {}
+        # Store last event seen monotonic timestamp by interface_id (DST-safe)
+        self._last_event_monotonic_for_interface: Final[dict[str, float]] = {}
 
         # Store data point subscription unsubscribe callbacks for cleanup
         self._data_point_unsubscribes: Final[list[Callable[[], None]]] = []
@@ -257,6 +260,23 @@ class EventCoordinator(
             )
         )
 
+    def get_last_event_monotonic_for_interface(self, *, interface_id: str) -> float | None:
+        """
+        Return the last event monotonic timestamp for an interface.
+
+        Uses time.monotonic() which is immune to DST and wall-clock adjustments.
+
+        Args:
+        ----
+            interface_id: Interface identifier
+
+        Returns:
+        -------
+            Monotonic timestamp of last event or None if no event seen yet
+
+        """
+        return self._last_event_monotonic_for_interface.get(interface_id)
+
     def get_last_event_seen_for_interface(self, *, interface_id: str) -> datetime | None:
         """
         Return the last event seen for an interface.
@@ -385,6 +405,7 @@ class EventCoordinator(
 
         """
         self._last_event_seen_for_interface[interface_id] = datetime.now()
+        self._last_event_monotonic_for_interface[interface_id] = time.monotonic()
 
         # Update health tracker with event received
         self._health_tracker.record_event_received(interface_id=interface_id)

--- a/aiohomematic/central/health.py
+++ b/aiohomematic/central/health.py
@@ -47,6 +47,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import datetime
 from enum import Enum
+import time
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohomematic.client import CircuitState
@@ -176,6 +177,10 @@ class ConnectionHealth(ConnectionHealthProtocol):
     last_successful_request: datetime | None = None
     last_failed_request: datetime | None = None
     last_event_received: datetime | None = None
+    # Monotonic timestamps for DST-safe duration calculations
+    last_successful_request_monotonic: float = 0.0
+    last_failed_request_monotonic: float = 0.0
+    last_event_received_monotonic: float = 0.0
     consecutive_failures: int = 0
     reconnect_attempts: int = 0
     last_reconnect_attempt: datetime | None = None
@@ -190,10 +195,9 @@ class ConnectionHealth(ConnectionHealthProtocol):
         """
         if not self.is_connected:
             return False
-        if self.last_event_received is None:
+        if self.last_event_received_monotonic == 0.0:
             return False
-        age = (datetime.now() - self.last_event_received).total_seconds()
-        return age < EVENT_STALENESS_THRESHOLD
+        return (time.monotonic() - self.last_event_received_monotonic) < EVENT_STALENESS_THRESHOLD
 
     @property
     def health_score(self) -> float:
@@ -237,8 +241,8 @@ class ConnectionHealth(ConnectionHealthProtocol):
         # Recent Activity (30% total - 15% each for request and event)
         activity_weight = _WEIGHT_RECENT_ACTIVITY / 2
 
-        if self.last_successful_request:
-            age = (datetime.now() - self.last_successful_request).total_seconds()
+        if self.last_successful_request_monotonic > 0.0:
+            age = time.monotonic() - self.last_successful_request_monotonic
             if age < 60:
                 score += activity_weight
             elif age < 300:
@@ -246,8 +250,8 @@ class ConnectionHealth(ConnectionHealthProtocol):
             elif age < 600:
                 score += activity_weight * 0.33
 
-        if self.last_event_received:
-            age = (datetime.now() - self.last_event_received).total_seconds()
+        if self.last_event_received_monotonic > 0.0:
+            age = time.monotonic() - self.last_event_received_monotonic
             if age < 60:
                 score += activity_weight
             elif age < 300:
@@ -298,10 +302,12 @@ class ConnectionHealth(ConnectionHealthProtocol):
     def record_event_received(self) -> None:
         """Record that an event was received from the backend."""
         self.last_event_received = datetime.now()
+        self.last_event_received_monotonic = time.monotonic()
 
     def record_failed_request(self) -> None:
         """Record a failed RPC request."""
         self.last_failed_request = datetime.now()
+        self.last_failed_request_monotonic = time.monotonic()
         self.consecutive_failures += 1
 
     def record_reconnect_attempt(self) -> None:
@@ -312,6 +318,7 @@ class ConnectionHealth(ConnectionHealthProtocol):
     def record_successful_request(self) -> None:
         """Record a successful RPC request."""
         self.last_successful_request = datetime.now()
+        self.last_successful_request_monotonic = time.monotonic()
         self.consecutive_failures = 0
 
     def reset_reconnect_counter(self) -> None:

--- a/aiohomematic/client/interface_client.py
+++ b/aiohomematic/client/interface_client.py
@@ -14,6 +14,7 @@ Public API
 import asyncio
 from datetime import datetime
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohomematic import i18n
@@ -96,6 +97,7 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
         "_is_callback_alive",
         "_last_value_send_tracker",
         "_modified_at",
+        "_modified_at_monotonic",
         "_paramset_description_coalescer",
         "_ping_pong_tracker",
         "_reconnect_attempts",
@@ -158,6 +160,7 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
             burst_window=central.config.timeout_config.burst_window,
         )
         self._modified_at: datetime = INIT_DATETIME
+        self._modified_at_monotonic: float = 0.0
 
         # Subscribe to connection state changes
         self._unsubscribe_system_status = central.event_bus.subscribe(
@@ -205,6 +208,7 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
     def modified_at(self, value: datetime) -> None:
         """Write the last update datetime value."""
         self._modified_at = value
+        self._modified_at_monotonic = time.monotonic() if value != INIT_DATETIME else 0.0
 
     async def accept_device_in_inbox(self, *, device_address: str) -> bool:
         """Accept a device from the CCU inbox."""
@@ -765,12 +769,12 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
             return False
 
         if (
-            last_events_dt := self._central.event_coordinator.get_last_event_seen_for_interface(
+            last_event_monotonic := self._central.event_coordinator.get_last_event_monotonic_for_interface(
                 interface_id=self.interface_id
             )
         ) is not None:
             callback_warn = self._central.config.timeout_config.callback_warn_interval
-            if (seconds_since_last_event := (datetime.now() - last_events_dt).total_seconds()) > callback_warn:
+            if (seconds_since_last_event := time.monotonic() - last_event_monotonic) > callback_warn:
                 if self._is_callback_alive:
                     self._central.event_bus.publish_sync(
                         event=SystemStatusChangedEvent(
@@ -782,7 +786,9 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
                     self._record_callback_timeout_incident(
                         seconds_since_last_event=seconds_since_last_event,
                         callback_warn_interval=callback_warn,
-                        last_event_time=last_events_dt,
+                        last_event_time=self._central.event_coordinator.get_last_event_seen_for_interface(
+                            interface_id=self.interface_id
+                        ),
                     )
                 _LOGGER.error(
                     i18n.tr(
@@ -829,7 +835,7 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
             return True
 
         callback_warn = self._central.config.timeout_config.callback_warn_interval
-        return (datetime.now() - self.modified_at).total_seconds() < callback_warn
+        return self._modified_at_monotonic > 0.0 and (time.monotonic() - self._modified_at_monotonic) < callback_warn
 
     async def list_devices(self) -> tuple[DeviceDescription, ...] | None:
         """List devices of the backend."""
@@ -1032,7 +1038,7 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
         self,
         *,
         on: bool = True,
-        time: int = 60,
+        time: int = 60,  # pylint: disable=redefined-outer-name
         mode: int = 1,
         device_address: str | None = None,
     ) -> bool:
@@ -1470,7 +1476,7 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
         *,
         seconds_since_last_event: float,
         callback_warn_interval: float,
-        last_event_time: datetime,
+        last_event_time: datetime | None,
     ) -> None:
         """Record a CALLBACK_TIMEOUT incident for diagnostics."""
         incident_recorder = self._central.cache_coordinator.incident_store
@@ -1483,7 +1489,7 @@ class InterfaceClient(ClientProtocol, LogContextMixin):
         context = {
             "seconds_since_last_event": round(seconds_since_last_event, 2),
             "callback_warn_interval": callback_warn_interval,
-            "last_event_time": last_event_time.strftime(DATETIME_FORMAT_MILLIS),
+            "last_event_time": last_event_time.strftime(DATETIME_FORMAT_MILLIS) if last_event_time else "unknown",
             "client_state": self._state_machine.state.value,
             "circuit_breaker_state": circuit_breaker_state,
         }

--- a/aiohomematic/interfaces/client.py
+++ b/aiohomematic/interfaces/client.py
@@ -868,6 +868,10 @@ class LastEventTrackerProtocol(Protocol):
     """
 
     @abstractmethod
+    def get_last_event_monotonic_for_interface(self, *, interface_id: str) -> float | None:
+        """Get the last event monotonic timestamp for an interface (DST-safe)."""
+
+    @abstractmethod
     def get_last_event_seen_for_interface(self, *, interface_id: str) -> datetime | None:
         """Get the last event timestamp for an interface."""
 

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,14 @@
 
 ### Fixed
 
+- **DST-safe callback alive and connection checks**: Replaced `datetime.now()`
+  with `time.monotonic()` for all duration calculations in `is_callback_alive()`,
+  `is_connected()`, and `ConnectionHealth` scoring. Wall-clock time jumps during
+  DST transitions (or NTP corrections) caused false callback timeout detections
+  (e.g. 3602s instead of 2s after a spring-forward). Monotonic timestamps are
+  immune to clock adjustments. The `LastEventTrackerProtocol` gains a new
+  `get_last_event_monotonic_for_interface()` method.
+
 - **Alarm messages not returned**: Fixed ReGa script `get_alarm_messages.fn`
   not returning active alarm messages. The script required a resolvable trigger
   data point (`AlTriggerDP`), but system alarms (e.g. WatchDog) use the

--- a/tests/contract/test_capability_contract.py
+++ b/tests/contract/test_capability_contract.py
@@ -21,6 +21,7 @@ See ADR-0018 for architectural context and rationale.
 """
 
 from datetime import datetime, timedelta
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -76,6 +77,10 @@ class _FakeEventCoordinator:
 
     def __init__(self, *, last_event_time: datetime | None = None) -> None:
         self._last_event_time = last_event_time
+
+    def get_last_event_monotonic_for_interface(self, *, interface_id: str) -> float | None:
+        """Return the last event monotonic timestamp for an interface."""
+        return time.monotonic() if self._last_event_time is not None else None
 
     def get_last_event_seen_for_interface(self, *, interface_id: str) -> datetime | None:
         """Return the last event time for an interface."""

--- a/tests/test_central.py
+++ b/tests/test_central.py
@@ -1393,6 +1393,7 @@ class TestCentralEventHandling:
         # Create a bare EventCoordinator instance
         event_coordinator = EventCoordinator.__new__(EventCoordinator)  # type: ignore[call-arg]
         event_coordinator._last_event_seen_for_interface = {}  # type: ignore[attr-defined]
+        event_coordinator._last_event_monotonic_for_interface = {}  # type: ignore[attr-defined]
 
         # Mock health_tracker for event recording
         mock_health_tracker = MagicMock()

--- a/tests/test_central_state_machine.py
+++ b/tests/test_central_state_machine.py
@@ -3,6 +3,7 @@
 """Tests for the Central State Machine architecture."""
 
 from datetime import datetime
+import time
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -146,6 +147,8 @@ class TestConnectionHealth:
             xml_rpc_circuit=CircuitState.CLOSED,
             last_successful_request=datetime.now(),
             last_event_received=datetime.now(),
+            last_successful_request_monotonic=time.monotonic(),
+            last_event_received_monotonic=time.monotonic(),
         )
         assert health.health_score >= 0.9
 

--- a/tests/test_command_throttle.py
+++ b/tests/test_command_throttle.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import datetime
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -371,6 +372,10 @@ class _FakeCentral:
         """Return generic data point."""
         key = f"{channel_address}:{parameter}:{paramset_key}"
         return self._data_points.get(key)
+
+    def get_last_event_monotonic_for_interface(self, *, interface_id: str) -> float | None:
+        """Return last event monotonic timestamp."""
+        return time.monotonic()
 
     def get_last_event_seen_for_interface(self, *, interface_id: str) -> datetime | None:
         """Return last event timestamp."""

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,6 +3,7 @@
 """Tests for Health Tracking System."""
 
 from datetime import datetime, timedelta
+import time
 from unittest.mock import MagicMock
 
 from aiohomematic.central import CentralHealth, ConnectionHealth, HealthTracker
@@ -40,6 +41,7 @@ class TestConnectionHealth:
             interface=Interface.HMIP_RF,
             client_state=ClientState.CONNECTED,
             last_event_received=datetime.now(),
+            last_event_received_monotonic=time.monotonic(),
         )
         assert health.can_receive_events is True
 
@@ -50,6 +52,7 @@ class TestConnectionHealth:
             interface=Interface.HMIP_RF,
             client_state=ClientState.CONNECTED,
             last_event_received=datetime.now() - timedelta(minutes=10),
+            last_event_received_monotonic=time.monotonic() - 600,
         )
         assert health.can_receive_events is False
 
@@ -85,6 +88,8 @@ class TestConnectionHealth:
             json_rpc_circuit=None,  # No JSON-RPC
             last_successful_request=datetime.now(),
             last_event_received=datetime.now(),
+            last_successful_request_monotonic=time.monotonic(),
+            last_event_received_monotonic=time.monotonic(),
         )
         # Should be close to 1.0
         assert health.health_score >= 0.9
@@ -122,6 +127,8 @@ class TestConnectionHealth:
             xml_rpc_circuit=CircuitState.CLOSED,
             last_successful_request=datetime.now() - timedelta(minutes=8),
             last_event_received=datetime.now() - timedelta(minutes=8),
+            last_successful_request_monotonic=time.monotonic() - 480,
+            last_event_received_monotonic=time.monotonic() - 480,
         )
         # Should still have some score but reduced
         score = health.health_score

--- a/tests/test_interface_client_backends.py
+++ b/tests/test_interface_client_backends.py
@@ -10,6 +10,7 @@ These tests verify that InterfaceClient correctly handles:
 """
 
 from datetime import datetime
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -132,6 +133,7 @@ class _FakeCentral:
     def event_coordinator(self) -> Any:
         return SimpleNamespace(
             get_last_event_seen_for_interface=lambda *, interface_id: datetime.now(),
+            get_last_event_monotonic_for_interface=lambda *, interface_id: time.monotonic(),
         )
 
     @property

--- a/tests/test_interface_client_comparison.py
+++ b/tests/test_interface_client_comparison.py
@@ -14,6 +14,7 @@ the legacy ClientCCU/DeviceHandler implementation for:
 
 import asyncio
 from datetime import datetime
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -307,6 +308,9 @@ class _FakeCentral:
     def get_generic_data_point(self, *, channel_address: str, parameter: str, paramset_key: ParamsetKey) -> Any:
         key = f"{channel_address}:{parameter}:{paramset_key}"
         return self._data_points.get(key)
+
+    def get_last_event_monotonic_for_interface(self, *, interface_id: str) -> float | None:
+        return time.monotonic()
 
     def get_last_event_seen_for_interface(self, *, interface_id: str) -> datetime | None:
         return datetime.now()

--- a/tests/test_interface_client_lifecycle.py
+++ b/tests/test_interface_client_lifecycle.py
@@ -12,6 +12,7 @@ These tests verify the connection lifecycle operations:
 """
 
 from datetime import datetime, timedelta
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -255,6 +256,7 @@ class _FakeCentral:
         self._data_points: dict[str, Any] = {}
         self.name = "test-central"
         self._last_event_seen: datetime | None = datetime.now()
+        self._last_event_monotonic: float | None = time.monotonic()
 
         class Cfg:
             host = "localhost"
@@ -331,6 +333,9 @@ class _FakeCentral:
         parent = self
 
         class _FakeEventCoordinator:
+            def get_last_event_monotonic_for_interface(self, *, interface_id: str) -> float | None:
+                return parent._last_event_monotonic
+
             def get_last_event_seen_for_interface(self, *, interface_id: str) -> datetime | None:
                 return parent._last_event_seen
 
@@ -665,6 +670,7 @@ class TestInterfaceClientIsCallbackAlive:
         central = _FakeCentral()
         # Set last event to 10 minutes ago (longer than default callback_warn_interval of 3 minutes)
         central._last_event_seen = datetime.now() - timedelta(minutes=10)
+        central._last_event_monotonic = time.monotonic() - 600
         backend = _FakeBackend()
         client = _create_interface_client(central, backend)
 
@@ -676,6 +682,7 @@ class TestInterfaceClientIsCallbackAlive:
         """is_callback_alive should publish SystemStatusChangedEvent when state changes."""
         central = _FakeCentral()
         central._last_event_seen = datetime.now() - timedelta(minutes=10)
+        central._last_event_monotonic = time.monotonic() - 600
         backend = _FakeBackend()
         client = _create_interface_client(central, backend)
 
@@ -1587,6 +1594,7 @@ class TestIsCallbackAliveStateTransition:
         """is_callback_alive should not re-publish dead event when already marked dead."""
         central = _FakeCentral()
         central._last_event_seen = datetime.now() - timedelta(minutes=10)
+        central._last_event_monotonic = time.monotonic() - 600
         backend = _FakeBackend()
         client = _create_interface_client(central, backend)
 
@@ -1653,6 +1661,7 @@ class TestIsConnectedPushUpdates:
         backend.capabilities.push_updates = False
         # Set last event very old to test that callback_warn is NOT checked
         central._last_event_seen = datetime.now() - timedelta(hours=1)
+        central._last_event_monotonic = time.monotonic() - 3600
         client = _create_interface_client(central, backend)
 
         result = await client.is_connected()


### PR DESCRIPTION
Track and use time.monotonic() for event/request timing to make staleness and health calculations DST- and wall-clock-adjustment safe. Added monotonic timestamp storage in EventCoordinator and ConnectionHealth, a new get_last_event_monotonic_for_interface API on the last-event protocol, and modified InterfaceClient to maintain and check a _modified_at_monotonic. Replaced datetime-based age calculations with monotonic differences where appropriate, updated incident formatting to handle missing last-event datetime, and adjusted tests to set/expect the new monotonic fields.