### PR TITLE
Always populate unconfirmed value on set

### DIFF
--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.4.0"
+VERSION: Final = "2026.4.1"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (

--- a/aiohomematic/model/data_point.py
+++ b/aiohomematic/model/data_point.py
@@ -1219,8 +1219,8 @@ class BaseParameterDataPoint[
             self._set_unconfirmed_refreshed_at(refreshed_at=write_at)
         else:
             self._set_unconfirmed_modified_at(modified_at=write_at)
-            self._unconfirmed_value = temp_value
             self._state_uncertain = True
+        self._unconfirmed_value = temp_value
         self.publish_data_point_updated_event(old_value=old_value, new_value=temp_value)
 
     def write_value(self, *, value: Any, write_at: datetime) -> tuple[ParameterT | None, ParameterT | None]:

--- a/aiohomematic/model/hub/data_point.py
+++ b/aiohomematic/model/hub/data_point.py
@@ -264,8 +264,8 @@ class GenericSysvarDataPoint(GenericHubDataPoint, GenericSysvarDataPointProtocol
             self._set_unconfirmed_refreshed_at(refreshed_at=write_at)
         else:
             self._set_unconfirmed_modified_at(modified_at=write_at)
-            self._unconfirmed_value = temp_value
             self._state_uncertain = True
+        self._unconfirmed_value = temp_value
         self.publish_data_point_updated_event()
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+# Version 2026.4.1 (2026-04-04)
+
+## What's Changed
+
+### Fixed
+
+- **Fixed sysvar and device data points temporarily showing unknown after setting
+  the same value**: When `send_variable()` or `send_value()` was called with a
+  value identical to the already confirmed value, the unconfirmed value was not
+  populated (remained `None`) while the unconfirmed timestamp was updated. This
+  caused `_value` to return `None` (shown as "unknown" in Home Assistant) until
+  the next polling cycle confirmed the value (~20-30 seconds). The issue was more
+  likely to occur with rapid value changes or when setting to 0. Fixed by always
+  populating `_unconfirmed_value` regardless of whether the value changed.
+  Fixes #3090.
+
 # Version 2026.4.0 (2026-04-03)
 
 ## What's Changed

--- a/tests/test_model_number.py
+++ b/tests/test_model_number.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021-2026
 """Tests for number data points of aiohomematic."""
 
+from datetime import datetime
 from typing import cast
 from unittest.mock import call
 
@@ -221,6 +222,82 @@ class TestSysvarNumber:
         await enumber.send_variable(value=35.0)
         # value over max won't change value
         assert enumber.value == 23.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            ({}, True, None, None),
+        ],
+    )
+    async def test_sysvar_number_no_unknown_after_poll_with_old_value(
+        self,
+        central_client_factory_with_ccu_client,
+    ) -> None:
+        """Test that poll returning old value after set does not cause unknown."""
+        central, mock_client, _ = central_client_factory_with_ccu_client
+        enumber: SysvarDpNumber = cast(
+            SysvarDpNumber,
+            central.hub_coordinator.get_sysvar_data_point(legacy_name="float_ext"),
+        )
+        # Initial state from session data
+        assert enumber.value == 23.2
+
+        # User sets a new value
+        await enumber.send_variable(value=10.0)
+        assert enumber.value == 10.0
+        assert enumber.state_uncertain is True
+
+        # Poll returns old value (CCU hasn't processed the change yet)
+        enumber.write_value(value=23.2, write_at=datetime.now())
+        assert enumber.value == 23.2
+        assert enumber.state_uncertain is False
+
+        # User sets the same value again (now matches _current_value)
+        await enumber.send_variable(value=23.2)
+        # Must NOT become None/unknown
+        assert enumber.value is not None
+        assert enumber.value == 23.2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        (
+            "address_device_translation",
+            "do_mock_client",
+            "ignore_devices_on_create",
+            "un_ignore_list",
+        ),
+        [
+            ({}, True, None, None),
+        ],
+    )
+    async def test_sysvar_number_no_unknown_on_same_value_set(
+        self,
+        central_client_factory_with_ccu_client,
+    ) -> None:
+        """Test that setting the same value does not cause unknown state."""
+        central, mock_client, _ = central_client_factory_with_ccu_client
+        enumber: SysvarDpNumber = cast(
+            SysvarDpNumber,
+            central.hub_coordinator.get_sysvar_data_point(legacy_name="float_ext"),
+        )
+        assert enumber.value == 23.2
+
+        # Simulate poll confirming the value
+        enumber.write_value(value=23.2, write_at=datetime.now())
+        assert enumber.value == 23.2
+        assert enumber.state_uncertain is False
+
+        # User sets the same value that is already confirmed
+        await enumber.send_variable(value=23.2)
+        # Value must NOT become None (which would show as "unknown" in HA)
+        assert enumber.value is not None
+        assert enumber.value == 23.2
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
Ensure _unconfirmed_value is set regardless of whether the new value equals the confirmed value to avoid temporary "unknown" states. Move assignment of _unconfirmed_value out of the branch that only ran on changed values in data_point and hub/data_point, add tests covering sysvar number behavior, update changelog, and bump version to 2026.4.1. Fixes #3090.
