### PR TITLE
Clamp schedule level_2 to [0.0, 1.0]

### DIFF
--- a/aiohomematic/model/schedule_models.py
+++ b/aiohomematic/model/schedule_models.py
@@ -667,8 +667,9 @@ def convert_raw_group_to_simple_entry(
     level = max(0.0, min(1.0, level))
 
     # Extract optional level_2 (for covers)
+    # Clamp to [0.0, 1.0] — some devices (e.g. HmIP-BROLL) report values like 1.01
     level_2_raw = group_data.get(ScheduleField.LEVEL_2)
-    level_2 = float(level_2_raw) if isinstance(level_2_raw, (int, float)) else None
+    level_2 = max(0.0, min(1.0, float(level_2_raw))) if isinstance(level_2_raw, (int, float)) else None
 
     # Extract optional duration
     duration: str | None = None

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version 2026.4.1 (2026-04-04)
+# Version 2026.4.1 (2026-04-05)
 
 ## What's Changed
 
@@ -13,6 +13,14 @@
   likely to occur with rapid value changes or when setting to 0. Fixed by always
   populating `_unconfirmed_value` regardless of whether the value changed.
   Fixes #3090.
+
+- **Fixed device schedules appearing empty for cover and dimmer devices**: The CCU
+  reports `level_2` values slightly above 1.0 (e.g. 1.01) for some cover devices
+  like HmIP-BROLL. The Pydantic validation on `SimpleScheduleEntry.level_2`
+  (`le=1.0`) rejected these values, causing the entire schedule group to be
+  silently skipped. Fixed by clamping `level_2` to `[0.0, 1.0]` in
+  `convert_raw_group_to_simple_entry()`, consistent with the existing `level`
+  clamping. Fixes #3092.
 
 # Version 2026.4.0 (2026-04-03)
 

--- a/tests/test_model_week_profile.py
+++ b/tests/test_model_week_profile.py
@@ -1718,6 +1718,48 @@ class TestDefaultWeekProfileAdditionalEdgeCases:
         assert result["01_WP_LEVEL"] == 0.5
         assert result["01_WP_LEVEL_2"] == 0.75
 
+    def test_convert_raw_to_dict_schedule_clamps_level_2_above_1(self):
+        """Test that LEVEL_2 values > 1.0 from CCU are clamped to 1.0."""
+        raw_schedule = {
+            "01_WP_WEEKDAY": 2,  # MONDAY
+            "01_WP_TARGET_CHANNELS": 1,  # CHANNEL_1_1
+            "01_WP_LEVEL": 0.5,
+            "01_WP_LEVEL_2": 1.01,  # CCU returns 101% for some cover devices
+            "01_WP_FIXED_HOUR": 8,
+            "01_WP_FIXED_MINUTE": 0,
+            "01_WP_CONDITION": 0,
+            "01_WP_ASTRO_TYPE": 0,
+            "01_WP_ASTRO_OFFSET": 0,
+        }
+
+        result = DefaultWeekProfile.convert_raw_to_dict_schedule(raw_schedule=raw_schedule)
+
+        assert isinstance(result, SimpleSchedule)
+        assert 1 in result.entries
+        assert result.entries[1].level == 0.5
+        assert result.entries[1].level_2 == 1.0  # clamped from 1.01
+
+    def test_convert_raw_to_dict_schedule_clamps_level_2_below_0(self):
+        """Test that LEVEL_2 values < 0.0 from CCU are clamped to 0.0."""
+        raw_schedule = {
+            "01_WP_WEEKDAY": 2,  # MONDAY
+            "01_WP_TARGET_CHANNELS": 1,  # CHANNEL_1_1
+            "01_WP_LEVEL": 0.5,
+            "01_WP_LEVEL_2": -0.01,  # Negative value
+            "01_WP_FIXED_HOUR": 8,
+            "01_WP_FIXED_MINUTE": 0,
+            "01_WP_CONDITION": 0,
+            "01_WP_ASTRO_TYPE": 0,
+            "01_WP_ASTRO_OFFSET": 0,
+        }
+
+        result = DefaultWeekProfile.convert_raw_to_dict_schedule(raw_schedule=raw_schedule)
+
+        assert isinstance(result, SimpleSchedule)
+        assert 1 in result.entries
+        assert result.entries[1].level == 0.5
+        assert result.entries[1].level_2 == 0.0  # clamped from -0.01
+
     def test_convert_raw_to_dict_schedule_filters_inactive(self):
         """Test that inactive schedules (no weekdays/channels) are filtered."""
         # Schedule with no weekdays or channels should be filtered out


### PR DESCRIPTION
Clamp LEVEL_2 values when converting schedule groups so values slightly outside the valid range (e.g. 1.01 reported by some devices like HmIP-BROLL) are constrained to [0.0, 1.0]. This prevents Pydantic validation failures that could cause schedule groups to be skipped. Adds unit tests for clamping above 1.0 and below 0.0, and updates the changelog entry for the release (fixes #3092).