### PR TITLE
Ignore HmIP-WRC6-230 in visibility rules

### DIFF
--- a/aiohomematic/store/visibility/rules.py
+++ b/aiohomematic/store/visibility/rules.py
@@ -287,6 +287,7 @@ IGNORE_PARAMETERS_BY_DEVICE: Final[Mapping[Parameter, frozenset[ModelName]]] = {
             "HmIP-SFD",
             "HmIP-SMO230",
             "HmIP-WGT",
+            "HmIP-WRC6-230",
         }
     ),
     Parameter.VALVE_STATE: frozenset({"HmIP-FALMOT-C8", "HmIPW-FALMOT-C12", "HmIP-FALMOT-C12"}),

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Version 2026.4.2 (2026-04-06)
+# Version 2026.4.2 (2026-04-07)
 
 ## What's Changed
 


### PR DESCRIPTION
Add HmIP-WRC6-230 to the IGNORE_PARAMETERS_BY_DEVICE mapping so its relevant parameters are treated as ignored/hidden by the visibility rules. 