### PR TITLE
Support non-climate link roles & improve logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-        exclude: ^tests/fixtures/|aiohomematic/rega_scripts|.github/ISSUE_TEMPLATE/bug_report_de.yml|.github/scripts/analyze_issue.py|.github/workflows/close-insufficient-info.yml|docs/reference/glossary.md|docs/user/troubleshooting/homeassistant_troubleshooting.md|\.de\.md$|docs/glossary_terms.yml|script/translate_docs.py
+        exclude: ^tests/fixtures/|aiohomematic/rega_scripts|.github/ISSUE_TEMPLATE/bug_report_de.yml|.github/ISSUE_TEMPLATE/config.yml|.github/scripts/analyze_issue.py|.github/workflows/close-insufficient-info.yml|docs/reference/glossary.md|docs/user/troubleshooting/homeassistant_troubleshooting.md|\.de\.md$|docs/glossary_terms.yml|script/translate_docs.py
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4
     hooks:

--- a/aiohomematic/central/coordinators/configuration.py
+++ b/aiohomematic/central/coordinators/configuration.py
@@ -361,9 +361,23 @@ class ConfigurationCoordinator(ConfigurationFacadeProtocol):
                     interface_id=device.interface_id,
                     device_address=device.address,
                 )
-            except BaseHomematicException:
+            except BaseHomematicException as exc:
+                _LOGGER.debug(  # i18n-log: ignore
+                    "GET_CONFIGURABLE_DEVICES: skipping %s/%s (%s) due to %s: %s",
+                    device.interface_id,
+                    device.address,
+                    device.model,
+                    type(exc).__name__,
+                    exc,
+                )
                 continue
             if not channels:
+                _LOGGER.debug(
+                    "GET_CONFIGURABLE_DEVICES: skipping %s/%s (%s) - no configurable channels",
+                    device.interface_id,
+                    device.address,
+                    device.model,
+                )
                 continue
 
             channel_list: list[ConfigurableDeviceChannel] = []

--- a/aiohomematic/client/json_rpc.py
+++ b/aiohomematic/client/json_rpc.py
@@ -1778,7 +1778,7 @@ class AioJsonRpcAioHttpClient(LogContextMixin):
         if self._supported_methods is None:
             self._supported_methods = await self._get_supported_methods()
         if unsupported_methods := tuple(method for method in _JsonRpcMethod if method not in self._supported_methods):
-            _LOGGER.error(  # i18n-log: ignore
+            _LOGGER.warning(  # i18n-log: ignore
                 "CHECK_SUPPORTED_METHODS: methods not supported by the backend: %s",
                 ", ".join(unsupported_methods),
             )

--- a/aiohomematic/const.py
+++ b/aiohomematic/const.py
@@ -19,7 +19,7 @@ from typing import Any, Final, NamedTuple, Required, TypeAlias, TypedDict
 
 from pydantic import BaseModel, ConfigDict
 
-VERSION: Final = "2026.4.14"
+VERSION: Final = "2026.4.15"
 
 # Detect test speedup mode via environment
 _TEST_SPEEDUP: Final = (
@@ -1912,19 +1912,47 @@ _CLIMATE_TARGET_ROLES: Final[tuple[str, ...]] = ("CLIMATE", "SWITCH", "LEVEL")
 _CLIMATE_TRANSMITTER_RE: Final = re.compile(r"(?:CLIMATE|HEATING).*(?:TRANSMITTER|TRANSCEIVER)")
 _CLIMATE_RECEIVER_RE: Final = re.compile(r"(?:CLIMATE|HEATING).*(?:TRANSCEIVER|RECEIVER)")
 
+# Map exact LINK_*_ROLES values to a representative DataPointCategory so that
+# get_linkable_channels can recognize non-CLIMATE channels (switches, remotes,
+# locks, blinds, dimmers, sensors) as link-capable.
+_LINK_ROLE_TO_CATEGORY: Final[dict[str, DataPointCategory]] = {
+    "ALARM_MODE_CONDITIONAL_SWITCH": DataPointCategory.SWITCH,
+    "AV_CONTROL_ROOM_SENSOR": DataPointCategory.SENSOR,
+    "CONDITIONAL_SWITCH": DataPointCategory.SWITCH,
+    "KEYMATIC": DataPointCategory.LOCK,
+    "LEVEL": DataPointCategory.LIGHT,
+    "REMOTE_CONTROL": DataPointCategory.BUTTON,
+    "REMOTECONTROL_RECEIVER": DataPointCategory.BUTTON,
+    "SMOKE_DETECTOR_TEAM": DataPointCategory.BINARY_SENSOR,
+    "SMOKE_DETECTOR_TEAM_V2": DataPointCategory.BINARY_SENSOR,
+    "SWITCH": DataPointCategory.SWITCH,
+    "WCS_TIPTRONIC_SENSOR": DataPointCategory.BINARY_SENSOR,
+    "WEATHER_CS": DataPointCategory.SENSOR,
+    "WEATHER_T": DataPointCategory.SENSOR,
+    "WEATHER_TH": DataPointCategory.SENSOR,
+    "WEATHER_THP": DataPointCategory.SENSOR,
+    "WINDOW_SWITCH": DataPointCategory.BINARY_SENSOR,
+    "WINDOW_SWITCH_RECEIVER": DataPointCategory.BINARY_SENSOR,
+    "WINDOW_SWITCH_RECEIVER_V2": DataPointCategory.BINARY_SENSOR,
+    "WINMATIC": DataPointCategory.COVER,
+}
+
 
 def get_link_source_categories(
     *, source_roles: tuple[str, ...], channel_type_name: str
 ) -> tuple[DataPointCategory, ...]:
-    """Return the channel sender roles."""
+    """Return the channel sender categories."""
     result: set[DataPointCategory] = set()
     has_climate = False
     if _CLIMATE_TRANSMITTER_RE.search(channel_type_name):
         result.add(DataPointCategory.CLIMATE)
         has_climate = True
 
-    if not has_climate and source_roles and any("CLIMATE" in role for role in source_roles):
-        result.add(DataPointCategory.CLIMATE)
+    for role in source_roles:
+        if not has_climate and "CLIMATE" in role:
+            result.add(DataPointCategory.CLIMATE)
+        if (category := _LINK_ROLE_TO_CATEGORY.get(role)) is not None:
+            result.add(category)
 
     return tuple(result)
 
@@ -1932,19 +1960,18 @@ def get_link_source_categories(
 def get_link_target_categories(
     *, target_roles: tuple[str, ...], channel_type_name: str
 ) -> tuple[DataPointCategory, ...]:
-    """Return the channel receiver roles."""
+    """Return the channel receiver categories."""
     result: set[DataPointCategory] = set()
     has_climate = False
     if _CLIMATE_RECEIVER_RE.search(channel_type_name):
         result.add(DataPointCategory.CLIMATE)
         has_climate = True
 
-    if (
-        not has_climate
-        and target_roles
-        and any(cl_role in role for role in target_roles for cl_role in _CLIMATE_TARGET_ROLES)
-    ):
-        result.add(DataPointCategory.CLIMATE)
+    for role in target_roles:
+        if not has_climate and any(cl_role in role for cl_role in _CLIMATE_TARGET_ROLES):
+            result.add(DataPointCategory.CLIMATE)
+        if (category := _LINK_ROLE_TO_CATEGORY.get(role)) is not None:
+            result.add(category)
 
     return tuple(result)
 

--- a/aiohomematic/store/persistent/device.py
+++ b/aiohomematic/store/persistent/device.py
@@ -143,6 +143,10 @@ class DeviceDescriptionRegistry(
         }
         children = device_descriptions[device_address].get("CHILDREN", [])
         for channel_address in children:
+            # Some CCU firmwares include empty entries in CHILDREN (observed on
+            # HmIP-RCV-50 with OpenCCU). Skip them instead of raising.
+            if not channel_address:
+                continue
             device_descriptions[channel_address] = self.get_device_description(
                 interface_id=interface_id, address=channel_address
             )

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,42 @@
+# Version 2026.4.15 (2026-04-18)
+
+## What's Changed
+
+### Fixed
+
+- **Fixed `LinkCoordinator.get_linkable_channels` excluding non-CLIMATE channels**:
+  `get_link_source_categories` / `get_link_target_categories` only mapped CLIMATE
+  roles to a `DataPointCategory`, so channels with `LINK_SOURCE_ROLES` /
+  `LINK_TARGET_ROLES` such as `REMOTE_CONTROL` (HmIP-RCV-50), `SWITCH`, `KEYMATIC`,
+  `WINMATIC`, `LEVEL`, `WEATHER_*`, `WINDOW_SWITCH*`, etc. produced empty category
+  tuples and were filtered out as non-linkable. Added a `_LINK_ROLE_TO_CATEGORY`
+  mapping so all known link roles produce a non-empty category. Fixes the
+  homematicip-local-frontend "Add Direct Link" wizard not offering the HmIP-RCV-50
+  virtual remote (and other non-climate devices) as a target.
+- Downgrade log level for unsupported JSON-RPC methods from `error` to `warning`
+  in `AioJsonRpcAioHttpClient._check_supported_methods` — missing optional methods
+  do not indicate a failure and should not be reported as errors.
+- Log instead of silently swallowing `BaseHomematicException` in
+  `ConfigurationCoordinator.get_configurable_devices`. Devices whose
+  `get_configurable_channels` fails (e.g. due to a missing child description)
+  were dropped from the panel device list without any trace. They are still
+  skipped, but now emit a warning identifying interface, address, model, and
+  the underlying exception, so the root cause can be diagnosed instead of
+  hidden. A debug line also explains devices skipped because they have no
+  configurable channels.
+- **Fixed HmIP-RCV-50 (and similar devices) missing from the panel device list**:
+  `DeviceDescriptionRegistry.get_device_with_channels` iterated over every entry
+  in the parent's `CHILDREN` array and called `get_device_description` for each.
+  Some CCU firmwares (observed with OpenCCU and the virtual remote `HmIP-RCV-50`)
+  emit an empty-string entry in `CHILDREN`, causing a
+  `DescriptionNotFoundException` that propagated into
+  `ConfigurationCoordinator.get_configurable_devices` and removed the whole
+  device from the panel list. Empty entries are now skipped, consistent with
+  the existing filter in `Device.finalize_init`
+  (`aiohomematic/model/device.py:354`).
+
+---
+
 # Version 2026.4.14 (2026-04-16)
 
 ## What's Changed

--- a/tests/test_link_categories.py
+++ b/tests/test_link_categories.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021-2026
+"""Test get_link_source_categories / get_link_target_categories mappers."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiohomematic.const import DataPointCategory, get_link_source_categories, get_link_target_categories
+
+
+class TestGetLinkSourceCategories:
+    """Tests for get_link_source_categories."""
+
+    def test_climate_channel_with_other_role(self) -> None:
+        """A climate channel still maps non-climate roles to their category."""
+        result = set(get_link_source_categories(source_roles=("SWITCH",), channel_type_name="CLIMATE_TRANSMITTER"))
+        assert result == {DataPointCategory.CLIMATE, DataPointCategory.SWITCH}
+
+    def test_climate_role_substring(self) -> None:
+        """A role containing CLIMATE counts as CLIMATE."""
+        result = get_link_source_categories(source_roles=("CLIMATE_CONTROL",), channel_type_name="UNKNOWN")
+        assert result == (DataPointCategory.CLIMATE,)
+
+    def test_climate_transceiver_channel_name(self) -> None:
+        """A CLIMATE_TRANSCEIVER channel counts as CLIMATE."""
+        result = get_link_source_categories(source_roles=(), channel_type_name="HEATING_CLIMATECONTROL_TRANSCEIVER")
+        assert result == (DataPointCategory.CLIMATE,)
+
+    def test_climate_transmitter_channel_name(self) -> None:
+        """A CLIMATE_TRANSMITTER channel always counts as CLIMATE."""
+        result = get_link_source_categories(source_roles=(), channel_type_name="CLIMATE_TRANSMITTER")
+        assert result == (DataPointCategory.CLIMATE,)
+
+    def test_conditional_switch_roles(self) -> None:
+        """CONDITIONAL_SWITCH variants map to SWITCH."""
+        for role in ("CONDITIONAL_SWITCH", "ALARM_MODE_CONDITIONAL_SWITCH"):
+            result = get_link_source_categories(source_roles=(role,), channel_type_name="X")
+            assert result == (DataPointCategory.SWITCH,), role
+
+    def test_empty_inputs(self) -> None:
+        """Return empty tuple when no roles and no climate channel name."""
+        assert get_link_source_categories(source_roles=(), channel_type_name="SWITCH") == ()
+
+    def test_keymatic_role(self) -> None:
+        """KEYMATIC maps to LOCK."""
+        result = get_link_source_categories(source_roles=("KEYMATIC",), channel_type_name="KEYMATIC")
+        assert result == (DataPointCategory.LOCK,)
+
+    def test_level_role(self) -> None:
+        """LEVEL maps to LIGHT (dimmer / blind)."""
+        result = get_link_source_categories(source_roles=("LEVEL",), channel_type_name="DIMMER")
+        assert result == (DataPointCategory.LIGHT,)
+
+    def test_multiple_roles_combined(self) -> None:
+        """Multiple roles produce a union of categories."""
+        result = set(get_link_source_categories(source_roles=("SWITCH", "REMOTE_CONTROL"), channel_type_name="X"))
+        assert result == {DataPointCategory.SWITCH, DataPointCategory.BUTTON}
+
+    def test_remote_control_role(self) -> None:
+        """REMOTE_CONTROL maps to BUTTON (HmIP-RCV-50 KEY_TRANSCEIVER channels)."""
+        result = get_link_source_categories(source_roles=("REMOTE_CONTROL",), channel_type_name="KEY_TRANSCEIVER")
+        assert result == (DataPointCategory.BUTTON,)
+
+    def test_smoke_detector_roles(self) -> None:
+        """Smoke detector team roles map to BINARY_SENSOR."""
+        for role in ("SMOKE_DETECTOR_TEAM", "SMOKE_DETECTOR_TEAM_V2"):
+            result = get_link_source_categories(source_roles=(role,), channel_type_name="X")
+            assert result == (DataPointCategory.BINARY_SENSOR,), role
+
+    def test_switch_role(self) -> None:
+        """SWITCH maps to SWITCH."""
+        result = get_link_source_categories(source_roles=("SWITCH",), channel_type_name="SWITCH")
+        assert result == (DataPointCategory.SWITCH,)
+
+    def test_unknown_role_returns_empty(self) -> None:
+        """An unknown role is silently skipped (no entry added)."""
+        assert get_link_source_categories(source_roles=("TOTALLY_UNKNOWN_ROLE_XYZ",), channel_type_name="X") == ()
+
+    def test_weather_roles(self) -> None:
+        """Weather roles map to SENSOR."""
+        for role in ("WEATHER_T", "WEATHER_TH", "WEATHER_THP", "WEATHER_CS"):
+            result = get_link_source_categories(source_roles=(role,), channel_type_name="X")
+            assert result == (DataPointCategory.SENSOR,), role
+
+    def test_window_switch_roles(self) -> None:
+        """All WINDOW_SWITCH variants map to BINARY_SENSOR."""
+        for role in ("WINDOW_SWITCH", "WINDOW_SWITCH_RECEIVER", "WINDOW_SWITCH_RECEIVER_V2"):
+            result = get_link_source_categories(source_roles=(role,), channel_type_name="X")
+            assert result == (DataPointCategory.BINARY_SENSOR,), role
+
+    def test_winmatic_role(self) -> None:
+        """WINMATIC maps to COVER."""
+        result = get_link_source_categories(source_roles=("WINMATIC",), channel_type_name="WINMATIC")
+        assert result == (DataPointCategory.COVER,)
+
+
+class TestGetLinkTargetCategories:
+    """Tests for get_link_target_categories."""
+
+    def test_climate_receiver_channel_name(self) -> None:
+        """A CLIMATE_RECEIVER channel always counts as CLIMATE."""
+        result = get_link_target_categories(target_roles=(), channel_type_name="CLIMATE_RECEIVER")
+        assert result == (DataPointCategory.CLIMATE,)
+
+    def test_climate_role_target(self) -> None:
+        """CLIMATE_CONTROL target maps to CLIMATE."""
+        result = get_link_target_categories(target_roles=("CLIMATE_CONTROL",), channel_type_name="X")
+        assert result == (DataPointCategory.CLIMATE,)
+
+    def test_climate_via_target_role_substring(self) -> None:
+        """SWITCH target role causes CLIMATE classification (legacy behavior)."""
+        result = set(get_link_target_categories(target_roles=("SWITCH",), channel_type_name="X"))
+        # Legacy behavior: SWITCH/LEVEL targets imply CLIMATE *and* are now also
+        # reported as their own category.
+        assert DataPointCategory.CLIMATE in result
+        assert DataPointCategory.SWITCH in result
+
+    def test_empty_inputs(self) -> None:
+        """Return empty tuple when no roles and no climate channel name."""
+        assert get_link_target_categories(target_roles=(), channel_type_name="SWITCH") == ()
+
+    def test_keymatic_target(self) -> None:
+        """KEYMATIC target maps to LOCK."""
+        assert get_link_target_categories(target_roles=("KEYMATIC",), channel_type_name="X") == (
+            DataPointCategory.LOCK,
+        )
+
+    def test_remote_control_target(self) -> None:
+        """REMOTE_CONTROL target maps to BUTTON only."""
+        result = get_link_target_categories(target_roles=("REMOTE_CONTROL",), channel_type_name="KEY_TRANSCEIVER")
+        assert result == (DataPointCategory.BUTTON,)
+
+    def test_unknown_role_returns_empty(self) -> None:
+        """Unknown target role yields no category."""
+        assert get_link_target_categories(target_roles=("UNKNOWN_TARGET_ROLE",), channel_type_name="X") == ()
+
+    def test_winmatic_target(self) -> None:
+        """WINMATIC target maps to COVER."""
+        assert get_link_target_categories(target_roles=("WINMATIC",), channel_type_name="X") == (
+            DataPointCategory.COVER,
+        )
+
+
+class TestRcv50RegressionIssue52:
+    """
+    Regression test for HmIP-RCV-50 not appearing in linkable channels.
+
+    See https://github.com/SukramJ/homematicip-local-frontend/discussions/52
+    """
+
+    def test_rcv50_key_transceiver_is_link_capable(self) -> None:
+        """HmIP-RCV-50 KEY_TRANSCEIVER channels must produce a non-empty source category list."""
+        result = get_link_source_categories(source_roles=("REMOTE_CONTROL",), channel_type_name="KEY_TRANSCEIVER")
+        assert result, (
+            "REMOTE_CONTROL must yield a non-empty category tuple, otherwise "
+            "LinkCoordinator.get_linkable_channels filters HmIP-RCV-50 out."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_store_persistent.py
+++ b/tests/test_store_persistent.py
@@ -246,6 +246,35 @@ class TestDeviceDescriptionRegistry:
         assert "DEV2" in descs
 
     @pytest.mark.asyncio
+    async def test_get_device_with_channels_skips_empty_child_entry(self, tmp_path) -> None:
+        """Empty CHILDREN entries (observed on HmIP-RCV-50 / OpenCCU) must not raise."""
+        central = _CentralStub("Test Central", str(tmp_path))
+        ddr = DeviceDescriptionRegistry(
+            storage=central.create_device_storage(),
+            config_provider=central,
+        )
+
+        iface = "if1"
+        dev_addr = "HmIP-RCV-1"
+        ch_addr = f"{dev_addr}{ADDRESS_SEPARATOR}1"
+
+        ddr.add_device(
+            interface_id=iface,
+            device_description={
+                "ADDRESS": dev_addr,
+                "CHILDREN": [ch_addr, ""],  # empty entry from CCU
+                "TYPE": "HmIP-RCV-50",
+            },
+        )
+        ddr.add_device(
+            interface_id=iface,
+            device_description={"ADDRESS": ch_addr, "CHILDREN": [], "TYPE": "KEY_TRANSCEIVER"},
+        )
+
+        dev_map = ddr.get_device_with_channels(interface_id=iface, device_address=dev_addr)
+        assert set(dev_map.keys()) == {dev_addr, ch_addr}
+
+    @pytest.mark.asyncio
     async def test_get_raw_device_descriptions(self, tmp_path) -> None:
         """Test getting raw device descriptions list."""
         central = _CentralStub("Test Central", str(tmp_path))


### PR DESCRIPTION
Add mapping for LINK_* roles to DataPointCategory and update get_link_source/target to include those categories so non-CLIMATE channels (e.g. REMOTE_CONTROL, SWITCH, KEYMATIC, LEVEL, WINMATIC, WEATHER_*, WINDOW_SWITCH, etc.) are recognized as linkable. Add tests for link category mapping and a regression test for HmIP-RCV-50. Skip empty CHILDREN entries in DeviceDescriptionRegistry to avoid DescriptionNotFoundException for certain CCU firmwares. Downgrade unsupported JSON-RPC methods log from error to warning and add debug logging when get_configurable_channels fails or when devices have no configurable channels. Bump version to 2026.4.15 and update changelog.