### PR TITLE
Validate schedule writes against paramset description

### DIFF
--- a/aiohomematic/model/week_profile.py
+++ b/aiohomematic/model/week_profile.py
@@ -900,6 +900,7 @@ class DefaultWeekProfile(WeekProfile[SimpleSchedule]):
             channel_address=sca,
             paramset_key_or_link_address=ParamsetKey.MASTER,
             values=raw_schedule,
+            check_against_pd=True,
         )
 
     async def _get_raw_schedule(self) -> RAW_SCHEDULE_DICT:
@@ -1122,6 +1123,7 @@ class ClimateWeekProfile(WeekProfile[ClimateSchedule]):
                 channel_address=sca,
                 paramset_key_or_link_address=ParamsetKey.MASTER,
                 values=raw_schedule,
+                check_against_pd=True,
             )
 
     @inspector
@@ -1227,6 +1229,7 @@ class ClimateWeekProfile(WeekProfile[ClimateSchedule]):
             channel_address=sca,
             paramset_key_or_link_address=ParamsetKey.MASTER,
             values=self.convert_dict_to_raw_schedule(schedule_data={profile: converted_profile_data}),
+            check_against_pd=True,
         )
 
     @inspector
@@ -1249,6 +1252,7 @@ class ClimateWeekProfile(WeekProfile[ClimateSchedule]):
             channel_address=sca,
             paramset_key_or_link_address=ParamsetKey.MASTER,
             values=self.convert_dict_to_raw_schedule(schedule_data=converted_schedule_data),
+            check_against_pd=True,
         )
 
     @inspector

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,14 @@
   `_filter_raw_schedule_by_supported_fields` drops all unsupported `NN_WP_*`
   keys before `put_paramset`, so device schedule writes only send what the
   device actually accepts.
+- **Validate schedule writes against paramset description**: `WeekProfile` write
+  paths (`DefaultWeekProfile.set_schedule`, `ClimateWeekProfile.set_schedule`,
+  `set_profile`, `copy_schedule_to`) now pass `check_against_pd=True` to
+  `put_paramset`, matching the existing behavior of `set_weekday`. Previously,
+  unknown or unsupported `WP_*` parameters were forwarded to the CCU without
+  validation, where they were silently rejected or caused opaque errors. The
+  client now raises a clear `ClientException` listing the offending parameter
+  before the request is sent.
 
 ### Added
 


### PR DESCRIPTION
WeekProfile write paths (DefaultWeekProfile.set_schedule, ClimateWeekProfile.set_schedule, set_profile, copy_schedule_to) now pass check_against_pd=True to put_paramset, matching the existing behavior of set_weekday.

Previously, unknown or unsupported WP_* parameters (e.g. WP_CONDITION, WP_ASTRO_TYPE, WP_ASTRO_OFFSET on devices that do not expose them in their paramset description) were forwarded to the CCU without validation, where they were silently rejected or caused opaque errors. The client now raises a clear ClientException listing the offending parameter before the request is sent.